### PR TITLE
Set up headless testing with qunit-puppeteer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
   - "10"
-script:
+addons:
+  chrome: stable # have Travis install Chrome stable
+install:
   - npm install -g qunit-puppeteer
+script:
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - "10"
+dist: trusty
 # Note: if you switch to sudo: false, you'll need to launch Chrome with --no-sandbox.
 # See https://github.com/travis-ci/travis-ci/issues/8836
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - "10"
+script:
+  - npm install -g qunit-puppeteer
+  - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
   - "10"
+# Note: if you switch to sudo: false, you'll need to launch Chrome with --no-sandbox.
+# See https://github.com/travis-ci/travis-ci/issues/8836
+sudo: required
 addons:
   chrome: stable # have Travis install Chrome stable
 install:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: test
+
+test:
+	@# Note: this assumes you're running this on a Linux/macOS system
+	qunit-puppeteer file://$(shell pwd)/tests/index.html

--- a/README.md
+++ b/README.md
@@ -3,35 +3,6 @@
 
 Empress is currently being rebuilt. Please see legacy branch for the last stable build.
 
-## Running tests
+## Empress' tests
 
-Empress' JavaScript tests use [QUnit](https://qunitjs.com/), which is included
-in the `tests/vendor/` directory.
-
-You can run tests in two different ways:
-
-1. **Manually, in a web browser:** you can do this by just opening up
-   `tests/index.html` in your web browser of choice.
-2. **Headlessly, from the command line:** This can be done using the
-   [qunit-puppeteer](https://github.com/davidtaylorhq/qunit-puppeteer) package.
-See the next section for instructions on how to do this.
-
-### Running tests headlessly
-
-(These commands assume you're using a Linux or macOS system, and that you have
-Google Chrome installed. If this isn't the case, these commands might not work
-for you.)
-
-First off, install qunit-puppeteer. You only need to do this once for any
-computer you're running Empress on.
-
-```bash
-$ npm install -g qunit-puppeteer
-```
-
-Once qunit-puppeteer has been installed, you should be able to run tests from
-the command line!
-
-```bash
-$ make test
-```
+Please see the `tests/README.md` file for instructions on how to run Empress' tests.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Empress
+[![Build Status](https://travis-ci.org/biocore/empress.svg?branch=master)](https://travis-ci.org/biocore/empress)
 
 Empress is currently being rebuilt. Please see legacy branch for the last stable build.
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
+# Empress
+
 Empress is currently being rebuilt. Please see legacy branch for the last stable build.
+
+## Running tests
+
+Empress' JavaScript tests use [QUnit](https://qunitjs.com/), which is included
+in the `tests/vendor/` directory.
+
+You can run tests in two different ways:
+
+1. **Manually, in a web browser:** you can do this by just opening up
+   `tests/index.html` in your web browser of choice.
+2. **Headlessly, from the command line:** This can be done using the
+   [qunit-puppeteer](https://github.com/davidtaylorhq/qunit-puppeteer) package.
+See the next section for instructions on how to do this.
+
+### Running tests headlessly
+
+(These commands assume you're using a Linux or macOS system, and that you have
+Google Chrome installed. If this isn't the case, these commands might not work
+for you.)
+
+First off, install qunit-puppeteer. You only need to do this once for any
+computer you're running Empress on.
+
+```bash
+$ npm install -g qunit-puppeteer
+```
+
+Once qunit-puppeteer has been installed, you should be able to run tests from
+the command line!
+
+```bash
+$ make test
+```

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,7 +21,7 @@ First off, install qunit-puppeteer. You only need to do this once for any
 computer you're running Empress on.
 
 ```bash
-$ npm install -g qunit-puppeteer
+npm install -g qunit-puppeteer
 ```
 
 Once qunit-puppeteer has been installed, you should be able to run tests from

--- a/tests/README.md
+++ b/tests/README.md
@@ -29,5 +29,5 @@ the command line! (You'll need to run this from the root directory of the
 Empress repository -- that is, the one above this one.)
 
 ```bash
-$ make test
+make test
 ```

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,32 @@
+# Empress' tests
+
+Empress' JavaScript tests use [QUnit](https://qunitjs.com/), which is included
+in the `tests/vendor/` directory.
+
+You can run tests in two different ways:
+
+1. **Manually, in a web browser:** you can do this by just opening up
+   `tests/index.html` in your web browser of choice.
+2. **Headlessly, from the command line:** This can be done using the
+   [qunit-puppeteer](https://github.com/davidtaylorhq/qunit-puppeteer) package.
+   See the next section for instructions on how to do this.
+
+## Running Empress' tests headlessly
+
+(These commands assume you're using a Linux or macOS system, and that you have
+Google Chrome installed. If this isn't the case, these commands might not work
+for you.)
+
+First off, install qunit-puppeteer. You only need to do this once for any
+computer you're running Empress on.
+
+```bash
+$ npm install -g qunit-puppeteer
+```
+
+Once qunit-puppeteer has been installed, you should be able to run tests from
+the command line!
+
+```bash
+$ make test
+```

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,12 +1,12 @@
 # Empress' tests
 
 Empress' JavaScript tests use [QUnit](https://qunitjs.com/), which is included
-in the `tests/vendor/` directory.
+in the `vendor/` directory.
 
 You can run tests in two different ways:
 
 1. **Manually, in a web browser:** you can do this by just opening up
-   `tests/index.html` in your web browser of choice.
+   `index.html` in your web browser of choice.
 2. **Headlessly, from the command line:** This can be done using the
    [qunit-puppeteer](https://github.com/davidtaylorhq/qunit-puppeteer) package.
    See the next section for instructions on how to do this.
@@ -25,7 +25,8 @@ $ npm install -g qunit-puppeteer
 ```
 
 Once qunit-puppeteer has been installed, you should be able to run tests from
-the command line!
+the command line! (You'll need to run this from the root directory of the
+Empress repository -- that is, the one above this one.)
 
 ```bash
 $ make test


### PR DESCRIPTION
This should make headless testing on travis work, although this solution does have some inherent shortcomings [as documented here](https://github.com/biocore/empress/pull/111#issuecomment-542004164). This should at least get us up and running with Travis right now.

Other things worth noting:
- The travis YAML file is just a shortened version of the file @kwcantrell added in #111. ~~I don't think we need to be bound to Node.js 10 or anything -- I just wanted to be consistent :)~~
- As mentioned in #111, it would be good to eventually keep track of code coverage. I know Karma can do this (see e.g. [here](https://ariya.io/2013/10/code-coverage-of-qunit-tests-using-istanbul-and-karma)), and I'm sure there are ways to do this through Puppeteer (but I don't think a way currently exists for doing this through qunit-puppeteer in particular). There are lots of conceivable ways to get this done; I can try to work on that next if you'd like.

Thanks! @ElDeveloper / anyone else, let me know if you'd like me to change anything.