### PR TITLE
fixing the problem with nans in metadata

### DIFF
--- a/empress/support_files/templates/empress-template.html
+++ b/empress/support_files/templates/empress-template.html
@@ -86,7 +86,7 @@
         var tree = new BPTree(tArr, {{ names }});
 
         var canvas = document.getElementById('tree-surface')
-        var biom = new BIOMTable({{ obs_data }}, {{ sample_data }});
+        var biom = new BIOMTable({{ obs_data }}, {{ sample_data | tojson }});
         var empress = new Empress(tree, {{ tree_data | tojson }},
                                   {{ names_to_keys | tojson }}, biom, canvas);
         empress.initialize();


### PR DESCRIPTION
This issue is related to transform python types to JSON readable objects, see #126 