### PR TITLE
Add Empress class and add support for OrdinationResults in q2-empress

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ following commands:
 
 ```bash
 pip install git+https://github.com/biocore/empress.git
+pip install git+https://github.com/biocore/emperor.git
 qiime dev refresh-cache
 qiime empress
 ```

--- a/empress/_plot.py
+++ b/empress/_plot.py
@@ -169,21 +169,16 @@ def plot(
 
 
 def _make_emperor(ordination, metadata, feature_metadata, output_dir):
-    viz = Emperor(ordination, metadata, remote='./emperor-resources/')
+    viz = Emperor(ordination, metadata, remote='./emperor-resources')
     viz.width = '48vw'
     viz.height = '100vh; float: right'
 
     viz.copy_support_files(os.path.join(output_dir, 'emperor-resources'))
 
     html = viz.make_emperor(standalone=True)
-    # q2view has a bug where double slashes mess things up
-    html = html.replace('emperor-resources//', 'emperor-resources/')
     html = html.split('\n')
 
     emperor_base_dependencies = html[6]
-
-    # TODO: maybe not needed anymore
-    # html = html.replace(' null, ec;', ' null;')
 
     # line 14 is where the CSS includes start
     emperor_style = '\n'.join([line.strip().replace("'", '').replace(',', '')

--- a/empress/_plot.py
+++ b/empress/_plot.py
@@ -11,34 +11,23 @@ import pkg_resources
 
 import qiime2
 import q2templates
-from q2_types.tree import NewickFormat
-
-from jinja2 import Environment, FileSystemLoader
-from emperor import Emperor
-from skbio import OrdinationResults
-from bp import parse_newick, to_skbio_treenode
-from empress import tools
 import pandas as pd
-from empress.tree import Tree
-from shutil import copytree
+
+from q2_types.tree import NewickFormat
+from skbio import OrdinationResults
+from bp import parse_newick
+
+from empress.core import Empress
 
 SUPPORT_FILES = pkg_resources.resource_filename('empress', 'support_files')
 TEMPLATES = os.path.join(SUPPORT_FILES, 'templates')
 
 
-def plot(
-    output_dir: str,
-    tree: NewickFormat,
-    feature_table: pd.DataFrame,
-    sample_metadata: qiime2.Metadata,
-    pcoa: OrdinationResults = None,
-    feature_metadata: qiime2.Metadata = None,
-    ignore_missing_samples: bool = False,
-    filter_missing_features: bool = False
-) -> None:
-
-    # 1. Convert inputs to the formats we want
-
+def plot(output_dir: str, tree: NewickFormat, feature_table: pd.DataFrame,
+         sample_metadata: qiime2.Metadata, pcoa: OrdinationResults = None,
+         feature_metadata: qiime2.Metadata = None,
+         ignore_missing_samples: bool = False,
+         filter_missing_features: bool = False) -> None:
     # TODO: do not ignore the feature metadata when specified by the user
     if feature_metadata is not None:
         feature_metadata = feature_metadata.to_dataframe()
@@ -48,180 +37,17 @@ def plot(
     # path to the actual newick file
     with open(str(tree)) as file:
         t = parse_newick(file.readline())
-    empress_tree = Tree.from_tree(to_skbio_treenode(t))
-    tools.name_internal_nodes(empress_tree)
 
-    # 2. Now that we've converted/read/etc. all of the four input sources,
-    # ensure that the samples and features they describe "match up" sanely.
-
-    # Note that the feature_table we get from QIIME 2 (as an argument to this
-    # function) is set up such that the index describes sample IDs and the
-    # columns describe feature IDs. We transpose this table before sending it
-    # to tools.match_inputs() and keep using the transposed table for the rest
-    # of this visualizer.
-
-    feature_table, sample_metadata = tools.match_inputs(
-        empress_tree, feature_table.T, sample_metadata, feature_metadata,
-        ignore_missing_samples, filter_missing_features
-    )
-
-    # TODO: Add a check for empty samples/features in the table? Filtering this
-    # sorta stuff out would help speed things up (and would be good to report
-    # to the user on via warnings).
-
-    # 3. Go forward with creating the Empress visualization!
-
-    # extract balance parenthesis
-    bp_tree = list(t.B)
-
-    # Compute coordinates resulting from layout algorithm(s)
-    # TODO: figure out implications of screen size
-    layout_to_coordsuffix, default_layout = empress_tree.coords(4020, 4020)
-
-    tree_data = {}
-    names_to_keys = {}
-    for i, node in enumerate(empress_tree.postorder(include_self=True), 1):
-        tree_data[i] = {
-            'name': node.name,
-            'color': [0.75, 0.75, 0.75],
-            'sampVal': 1,
-            'visible': True,
-            'single_samp': False
-        }
-        # Add coordinate data from all layouts for this node
-        for layoutsuffix in layout_to_coordsuffix.values():
-            xcoord = "x" + layoutsuffix
-            ycoord = "y" + layoutsuffix
-            tree_data[i][xcoord] = getattr(node, xcoord)
-            tree_data[i][ycoord] = getattr(node, ycoord)
-        # Also add vertical bar coordinate info for the rectangular layout
-        if not node.is_tip():
-            tree_data[i]["highestchildyr"] = node.highestchildyr
-            tree_data[i]["lowestchildyr"] = node.lowestchildyr
-
-        if node.name in names_to_keys:
-            names_to_keys[node.name].append(i)
-        else:
-            names_to_keys[node.name] = [i]
-
-    names = []
-    for node in empress_tree.preorder(include_self=True):
-        names.append(node.name)
-
-    env = Environment(loader=FileSystemLoader(TEMPLATES))
-    temp = env.get_template('empress-template.html')
-
-    # Convert sample metadata to a JSON-esque format
-    sample_data = sample_metadata.to_dict(orient='index')
-
-    # TODO: Empress is currently storing all metadata as strings. This is
-    # memory intensive and won't scale well. We should convert all numeric
-    # data/compress metadata.
-
-    # This is used in biom-table. Currently this is only used to ignore null
-    # data (i.e. NaN and "unknown") and also determines sorting order. The
-    # original intent is to signal what columns are discrete/continuous.
-    # type of sample metadata (n - number, o - object)
-    sample_data_type = sample_metadata.dtypes.to_dict()
-    sample_data_type = {k: 'n' if pd.api.types.is_numeric_dtype(v) else 'o'
-                        for k, v in sample_data_type.items()}
-
-    # create a mapping of observation ids and the samples that contain them
-    obs_data = {}
-    feature_table = (feature_table > 0)
-    for _, series in feature_table.iteritems():
-        sample_ids = series[series].index.tolist()
-        obs_data[series.name] = sample_ids
-
-    data_to_render = {
-        'base_url': './support_files',
-        'tree': bp_tree,
-        'tree_data': tree_data,
-        'names_to_keys': names_to_keys,
-        'sample_data': sample_data,
-        'sample_data_type': sample_data_type,
-        'obs_data': obs_data,
-        'names': names,
-        'layout_to_coordsuffix': layout_to_coordsuffix,
-        'default_layout': default_layout,
-        'emperor_div': '',
-        'emperor_require_logic': '',
-        'emperor_style': '',
-        'emperor_base_dependencies': '',
-        'emperor_classes': ''
-    }
-
-    if pcoa is not None:
-        data_to_render.update(_make_emperor(pcoa, sample_metadata,
-                                            feature_metadata, output_dir))
-
-    main_page = temp.render(data_to_render)
-
-    copytree(SUPPORT_FILES, os.path.join(output_dir, 'support_files'))
+    viz = Empress(tree=t, table=feature_table,
+                  sample_metadata=sample_metadata,
+                  feature_metadata=feature_metadata, ordination=pcoa,
+                  ignore_missing_samples=ignore_missing_samples,
+                  filter_missing_features=filter_missing_features)
 
     with open(os.path.join(output_dir, 'empress.html'), 'w') as file:
-        file.write(main_page)
+        file.write(str(viz))
+
+    viz.copy_support_files(output_dir)
 
     index = os.path.join(TEMPLATES, 'index.html')
     q2templates.render(index, output_dir)
-
-
-def _make_emperor(ordination, metadata, feature_metadata, output_dir):
-    viz = Emperor(ordination, metadata, remote='./emperor-resources')
-    viz.width = '48vw'
-    viz.height = '100vh; float: right'
-
-    viz.copy_support_files(os.path.join(output_dir, 'emperor-resources'))
-
-    html = viz.make_emperor(standalone=True)
-    html = html.split('\n')
-
-    emperor_base_dependencies = html[6]
-
-    # line 14 is where the CSS includes start
-    emperor_style = '\n'.join([line.strip().replace("'", '').replace(',', '')
-                              for line in html[14:20]])
-
-    # main divs for emperor
-    emperor_div = '\n'.join(html[39:44])
-
-    # main js script
-    emperor_require_logic = '\n'.join(html[45:-3])
-
-    emperor_require_logic = emperor_require_logic.replace(
-        '/*__select_callback__*/', SELECTION_CALLBACK)
-
-    emperor_data = {
-        'emperor_div': emperor_div,
-        'emperor_require_logic': emperor_require_logic,
-        'emperor_style': emperor_style,
-        'emperor_base_dependencies': emperor_base_dependencies,
-        'emperor_classes': 'combined-plot-container'
-    }
-
-    return emperor_data
-
-
-# should be replaced for the string /*__select_callback__*/
-SELECTION_CALLBACK = """ var colorGroups = {}, color;
-for(var i=0; i < samples.length; i++) {
-  color = samples[i].material.color.getHexString();
-  if (colorGroups[color] === undefined) {
-    colorGroups[color] = [];
-  }
-  colorGroups[color].push(samples[i].name);
-}
-empress.colorSampleGroups(colorGroups);
-
-// 3 seconds before resetting
-setTimeout(function(){
-  empress.resetTree();
-  empress.drawTree();
-
-  samples.forEach(function(sample) {
-    sample.material.emissive.set(0x000000);
-  })
-
-  plotView.needsUpdate = true;
-}, 4000);
-"""

--- a/empress/_plot.py
+++ b/empress/_plot.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2019, QIIME 2 development team.
+# Copyright (c) 2016-2019, empress development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/empress/_plot.py
+++ b/empress/_plot.py
@@ -45,10 +45,8 @@ def plot(
 
     sample_metadata = sample_metadata.to_dataframe()
 
-    # create/parse tree
-    tree_file = str(tree)
     # path to the actual newick file
-    with open(tree_file) as file:
+    with open(str(tree)) as file:
         t = parse_newick(file.readline())
     empress_tree = Tree.from_tree(to_skbio_treenode(t))
     tools.name_internal_nodes(empress_tree)

--- a/empress/_plot.py
+++ b/empress/_plot.py
@@ -11,8 +11,10 @@ import pkg_resources
 
 import qiime2
 import q2templates
+import numpy as np
 import pandas as pd
 
+from scipy.spatial.distance import euclidean
 from q2_types.tree import NewickFormat
 from skbio import OrdinationResults
 from bp import parse_newick
@@ -27,10 +29,21 @@ def plot(output_dir: str, tree: NewickFormat, feature_table: pd.DataFrame,
          sample_metadata: qiime2.Metadata, pcoa: OrdinationResults = None,
          feature_metadata: qiime2.Metadata = None,
          ignore_missing_samples: bool = False,
-         filter_missing_features: bool = False) -> None:
+         filter_missing_features: bool = False,
+         number_of_features: int = 5) -> None:
     # TODO: do not ignore the feature metadata when specified by the user
     if feature_metadata is not None:
         feature_metadata = feature_metadata.to_dataframe()
+
+    if pcoa is not None and pcoa.features is not None:
+        # select the top N most important features based on the vector's
+        # magnitude (coped from q2-emperor)
+        feats = pcoa.features.copy()
+        origin = np.zeros_like(feats.columns)
+        feats['importance'] = feats.apply(euclidean, axis=1, args=(origin,))
+        feats.sort_values('importance', inplace=True, ascending=False)
+        feats.drop(['importance'], inplace=True, axis=1)
+        pcoa.features = feats[:number_of_features].copy()
 
     sample_metadata = sample_metadata.to_dataframe()
 

--- a/empress/core.py
+++ b/empress/core.py
@@ -46,9 +46,9 @@ class Empress():
             ``ordination`` object, should have an index set and it should match
             the identifiers in the ``ordination`` object.
         feature_metadata: pd.DataFrame, optional
-            DataFrame object with the metadata associated to the features in
-            the ``table`` and ``tree`` objects, should have an index set and it
-            should match the feature identifiers.
+            DataFrame object with the metadata associated to the names of
+            tips and/or internal nodes in the  ``tree`` object, should have an
+            index set and it should match at least one of these nodes' names.
         ordination: skbio.OrdinationResults, optional
             Object containing the computed values for an ordination method in
             scikit-bio. Currently supports skbio.stats.ordination.PCoA and

--- a/empress/core.py
+++ b/empress/core.py
@@ -9,6 +9,7 @@
 from empress.tree import Tree
 from empress.tools import name_internal_nodes, match_inputs
 
+import warnings
 import pkg_resources
 import os
 import pandas as pd
@@ -27,12 +28,70 @@ class Empress():
                  feature_metadata=None, ordination=None,
                  ignore_missing_samples=False, filter_missing_features=False,
                  resource_path=None):
+        """Visualize a phylogenetic tree
+
+        Use this object to interactively display a phylogenetic tree using the
+        Empress GUI.
+
+        Parameters
+        ----------
+        tree: bp.Tree:
+            The phylogenetic tree to visualize.
+        table: pd.DataFrame:
+            The matrix to visualize paired with the phylogenetic tree.
+        sample_metadata: pd.DataFrame
+            DataFrame object with the metadata associated to the samples in the
+            ``ordination`` object, should have an index set and it should match
+            the identifiers in the ``ordination`` object.
+        feature_metadata: pd.DataFrame, optional
+            DataFrame object with the metadata associated to the features in
+            the ``table`` and ``tree`` objects, should have an index set and it
+            should match the feature identifiers.
+        ordination: skbio.OrdinationResults, optional
+            Object containing the computed values for an ordination method in
+            scikit-bio. Currently supports skbio.stats.ordination.PCoA and
+            skbio.stats.ordination.RDA results.
+        ignore_missing_samples: bool, optional
+            If True, pads missing samples (i.e. samples in the table but not
+            the metadata) with placeholder metadata. If False, raises a
+            DataMatchingError if any such samples exist. (Note that in either
+            case, samples in the metadata but not in the table are filtered
+            out; and if no samples are shared between the table and metadata, a
+            DataMatchingError is raised regardless.) This is analogous to the
+            ignore_missing_samples flag in Emperor.
+        filter_missing_features: bool, optional
+            If True, filters features from the table that aren't present as
+            tips in the tree. If False, raises a DataMatchingError if any such
+            features exist. (Note that in either case, features in the tree but
+            not in the table are preserved.)
+        resource_path: str, optional
+            Load the resources from a user-specified remote location. If set to
+            None resources are loaded from the current directory.
+
+
+        Attributes
+        ----------
+        tree:
+            Phylogenetic tree.
+        table:
+            Contingency matrix for teh phylogeny.
+        samples:
+            Sample metadata.
+        features:
+            Feature metadata
+        ordination:
+            Ordination matrix to visualize simultaneously with the tree.
+        base_url:
+            Base path to the remote resources.
+        """
 
         self.tree = tree
         self.table = table
         self.samples = sample_metadata.copy()
 
         if feature_metadata is not None:
+            warnings.warn('Feature metadata is currently not supported',
+                          UserWarning)
             self.features = feature_metadata.copy()
         else:
             self.features = None
@@ -43,7 +102,6 @@ class Empress():
         if self.base_url is None:
             self.base_url = './'
 
-        # TODO: validate metadata
         self._validate_data(ignore_missing_samples, filter_missing_features)
 
     def _validate_data(self, ignore_missing_samples, filter_missing_features):
@@ -230,6 +288,9 @@ class Empress():
                                 remote='./emperor-resources')
         self._emperor.width = '48vw'
         self._emperor.height = '100vh; float: right'
+
+        # make the background white so it matches Empress
+        self._emperor.set_background_color('white')
 
         html = self._emperor.make_emperor(standalone=True)
         html = html.split('\n')

--- a/empress/core.py
+++ b/empress/core.py
@@ -167,10 +167,10 @@ class Empress():
 
         Notes
         -----
-        Once you generate the plot (and write it to a HTML file in a given directory)
-        you will need to copy the support files (the JS/CSS/etc. code needed to
-        view the visualization) to the same directory by calling the
-        ``copy_support_files`` method.
+        Once you generate the plot (and write it to a HTML file in a given
+        directory) you will need to copy the support files (the JS/CSS/etc.
+        code needed to view the visualization) to the same directory by calling
+        the ``copy_support_files`` method.
 
         See Also
         --------

--- a/empress/core.py
+++ b/empress/core.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2019, QIIME 2 development team.
+# Copyright (c) 2016-2019, empress development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -53,7 +53,7 @@ class Empress():
             Object containing the computed values for an ordination method in
             scikit-bio. Currently supports skbio.stats.ordination.PCoA and
             skbio.stats.ordination.RDA results.
-        ignore_missing_samples: bool, optional
+        ignore_missing_samples: bool, optional (default False)
             If True, pads missing samples (i.e. samples in the table but not
             the metadata) with placeholder metadata. If False, raises a
             DataMatchingError if any such samples exist. (Note that in either
@@ -61,7 +61,7 @@ class Empress():
             out; and if no samples are shared between the table and metadata, a
             DataMatchingError is raised regardless.) This is analogous to the
             ignore_missing_samples flag in Emperor.
-        filter_missing_features: bool, optional
+        filter_missing_features: bool, optional (default False)
             If True, filters features from the table that aren't present as
             tips in the tree. If False, raises a DataMatchingError if any such
             features exist. (Note that in either case, features in the tree but
@@ -76,11 +76,11 @@ class Empress():
         tree:
             Phylogenetic tree.
         table:
-            Contingency matrix for teh phylogeny.
+            Contingency matrix for the phylogeny.
         samples:
             Sample metadata.
         features:
-            Feature metadata
+            Feature metadata.
         ordination:
             Ordination matrix to visualize simultaneously with the tree.
         base_url:
@@ -180,7 +180,6 @@ class Empress():
         # _to_dict puts the data into a dictionary-like object for consumption
         data = self._to_dict()
 
-        # need to do something about low and high
         plot = main_template.render(data)
 
         return plot

--- a/empress/core.py
+++ b/empress/core.py
@@ -104,6 +104,15 @@ class Empress():
 
         self._validate_data(ignore_missing_samples, filter_missing_features)
 
+        if self.ordination is not None:
+            self._emperor = Emperor(
+                self.ordination, sample_metadata=self.samples,
+                feature_metadata=self.features,
+                ignore_missing_samples=ignore_missing_samples,
+                remote='./emperor-resources')
+        else:
+            self._emperor = None
+
     def _validate_data(self, ignore_missing_samples, filter_missing_features):
         # extract balance parenthesis
         self._bp_tree = list(self.tree.B)
@@ -139,7 +148,7 @@ class Empress():
         # copy the required resources
         copytree(SUPPORT_FILES, os.path.join(target, 'support_files'))
 
-        if self.ordination is not None:
+        if self._emperor is not None:
             self._emperor.copy_support_files(os.path.join(target,
                                                           'emperor-resources'))
 
@@ -175,7 +184,7 @@ class Empress():
         return plot
 
     def _to_dict(self):
-        """Convert processed data into a dictionary of decompositions
+        """Convert processed data into a dictionary
 
         Returns
         -------
@@ -259,7 +268,7 @@ class Empress():
             'emperor_classes': ''
         }
 
-        if self.ordination is not None:
+        if self._emperor is not None:
             data_to_render.update(self._scavenge_emperor())
 
         return data_to_render
@@ -284,8 +293,6 @@ class Empress():
         return env.get_template('empress-template.html')
 
     def _scavenge_emperor(self):
-        self._emperor = Emperor(self.ordination, self.samples,
-                                remote='./emperor-resources')
         self._emperor.width = '48vw'
         self._emperor.height = '100vh; float: right'
 

--- a/empress/core.py
+++ b/empress/core.py
@@ -106,8 +106,8 @@ class Empress():
 
         if self.ordination is not None:
             self._emperor = Emperor(
-                self.ordination, sample_metadata=self.samples,
-                feature_metadata=self.features,
+                self.ordination, mapping_file=self.samples,
+                feature_mapping_file=self.features,
                 ignore_missing_samples=ignore_missing_samples,
                 remote='./emperor-resources')
         else:
@@ -295,9 +295,6 @@ class Empress():
     def _scavenge_emperor(self):
         self._emperor.width = '48vw'
         self._emperor.height = '100vh; float: right'
-
-        # make the background white so it matches Empress
-        self._emperor.set_background_color('white')
 
         html = self._emperor.make_emperor(standalone=True)
         html = html.split('\n')

--- a/empress/core.py
+++ b/empress/core.py
@@ -300,6 +300,10 @@ class Empress():
         self._emperor.width = '48vw'
         self._emperor.height = '100vh; float: right'
 
+        # make the background white so it matches Empress
+        self._emperor.set_background_color('white')
+        self._emperor.set_axes(color='black')
+
         html = self._emperor.make_emperor(standalone=True)
         html = html.split('\n')
 

--- a/empress/core.py
+++ b/empress/core.py
@@ -295,6 +295,8 @@ class Empress():
         return env.get_template('empress-template.html')
 
     def _scavenge_emperor(self):
+        # can't make this 50vw because one of the plot containers has some
+        # padding that makes the divs stack on top of each other
         self._emperor.width = '48vw'
         self._emperor.height = '100vh; float: right'
 

--- a/empress/core.py
+++ b/empress/core.py
@@ -1,0 +1,284 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2019, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+from empress.tree import Tree
+from empress.tools import name_internal_nodes, match_inputs
+
+import pkg_resources
+import os
+import pandas as pd
+
+from shutil import copytree
+from emperor import Emperor
+from bp import to_skbio_treenode
+from jinja2 import Environment, FileSystemLoader
+
+SUPPORT_FILES = pkg_resources.resource_filename('empress', 'support_files')
+TEMPLATES = os.path.join(SUPPORT_FILES, 'templates')
+
+
+class Empress():
+    def __init__(self, tree, table, sample_metadata,
+                 feature_metadata=None, ordination=None,
+                 ignore_missing_samples=False, filter_missing_features=False,
+                 resource_path=None):
+
+        self.tree = tree
+        self.table = table
+        self.samples = sample_metadata.copy()
+
+        if feature_metadata is not None:
+            self.features = feature_metadata.copy()
+        else:
+            self.features = None
+
+        self.ordination = ordination
+
+        self.base_url = resource_path
+        if self.base_url is None:
+            self.base_url = './'
+
+        # TODO: validate metadata
+        self._validate_data(ignore_missing_samples, filter_missing_features)
+
+    def _validate_data(self, ignore_missing_samples, filter_missing_features):
+        # extract balance parenthesis
+        self._bp_tree = list(self.tree.B)
+
+        self.tree = Tree.from_tree(to_skbio_treenode(self.tree))
+        name_internal_nodes(self.tree)
+
+        # Note that the feature_table we get from QIIME 2 (as an argument to
+        # this function) is set up such that the index describes sample IDs and
+        # the columns describe feature IDs. We transpose this table before
+        # sending it to tools.match_inputs() and keep using the transposed
+        # table for the rest of this visualizer.
+        self.table, self.samples = match_inputs(self.tree, self.table.T,
+                                                self.samples, self.features,
+                                                ignore_missing_samples,
+                                                filter_missing_features)
+
+    def copy_support_files(self, target=None):
+        """Copies the support files to a target directory
+
+        If an ordination is included Emperor's support files will also be
+        copied over.
+
+        Parameters
+        ----------
+        target : str
+            The path where resources should be copied to. By default it copies
+            the files to ``self.base_url``.
+        """
+        if target is None:
+            target = self.base_url
+
+        # copy the required resources
+        copytree(SUPPORT_FILES, os.path.join(target, 'support_files'))
+
+        if self.ordination is not None:
+            self._emperor.copy_support_files(os.path.join(target,
+                                                          'emperor-resources'))
+
+    def __str__(self):
+        return self.make_empress()
+
+    def make_empress(self):
+        """Build an empress plot
+
+        Returns
+        -------
+        str
+            Formatted empress plot.
+
+        Notes
+        -----
+        Once you generate the plot you will need to copy the support files by
+        calling the ``copy_support_files`` method.
+
+        See Also
+        --------
+        empress.core.Empress.copy_support_files
+        """
+        main_template = self._get_template()
+
+        # _process_data does a lot of munging to the coordinates data and
+        # _to_dict puts the data into a dictionary-like object for consumption
+        data = self._to_dict()
+
+        # need to do something about low and high
+        plot = main_template.render(data)
+
+        return plot
+
+    def _to_dict(self):
+        """Convert processed data into a dictionary of decompositions
+
+        Returns
+        -------
+        dict
+            A dictionary describing the plots contained in the ordination
+            object and the sample + feature metadata.
+        """
+
+        # Compute coordinates resulting from layout algorithm(s)
+        # TODO: figure out implications of screen size
+        layout_to_coordsuffix, default_layout = self.tree.coords(4020, 4020)
+
+        tree_data = {}
+        names_to_keys = {}
+        for i, node in enumerate(self.tree.postorder(include_self=True), 1):
+            tree_data[i] = {
+                'name': node.name,
+                'color': [0.75, 0.75, 0.75],
+                'sampVal': 1,
+                'visible': True,
+                'single_samp': False
+            }
+            # Add coordinate data from all layouts for this node
+            for layoutsuffix in layout_to_coordsuffix.values():
+                xcoord = "x" + layoutsuffix
+                ycoord = "y" + layoutsuffix
+                tree_data[i][xcoord] = getattr(node, xcoord)
+                tree_data[i][ycoord] = getattr(node, ycoord)
+            # Also add vertical bar coordinate info for the rectangular layout
+            if not node.is_tip():
+                tree_data[i]["highestchildyr"] = node.highestchildyr
+                tree_data[i]["lowestchildyr"] = node.lowestchildyr
+
+            if node.name in names_to_keys:
+                names_to_keys[node.name].append(i)
+            else:
+                names_to_keys[node.name] = [i]
+
+        names = []
+        for node in self.tree.preorder(include_self=True):
+            names.append(node.name)
+
+        # Convert sample metadata to a JSON-esque format
+        sample_data = self.samples.to_dict(orient='index')
+
+        # TODO: Empress is currently storing all metadata as strings. This is
+        # memory intensive and won't scale well. We should convert all numeric
+        # data/compress metadata.
+
+        # This is used in biom-table. Currently this is only used to ignore
+        # null data (i.e. NaN and "unknown") and also determines sorting order.
+        # The original intent is to signal what columns are
+        # discrete/continuous.  type of sample metadata (n - number, o -
+        # object)
+        sample_data_type = self.samples.dtypes.to_dict()
+        sample_data_type = {k: 'n' if pd.api.types.is_numeric_dtype(v) else 'o'
+                            for k, v in sample_data_type.items()}
+
+        # create a mapping of observation ids and the samples that contain them
+        obs_data = {}
+        feature_table = (self.table > 0)
+        for _, series in feature_table.iteritems():
+            sample_ids = series[series].index.tolist()
+            obs_data[series.name] = sample_ids
+
+        data_to_render = {
+            'base_url': './support_files',
+            'tree': self._bp_tree,
+            'tree_data': tree_data,
+            'names_to_keys': names_to_keys,
+            'sample_data': sample_data,
+            'sample_data_type': sample_data_type,
+            'obs_data': obs_data,
+            'names': names,
+            'layout_to_coordsuffix': layout_to_coordsuffix,
+            'default_layout': default_layout,
+            'emperor_div': '',
+            'emperor_require_logic': '',
+            'emperor_style': '',
+            'emperor_base_dependencies': '',
+            'emperor_classes': ''
+        }
+
+        if self.ordination is not None:
+            data_to_render.update(self._scavenge_emperor())
+
+        return data_to_render
+
+    def _get_template(self, standalone=False):
+        """Get the jinja template object
+
+        Parameters
+        ----------
+        standalone: bool, optional
+            Whether or not the generated plot will load resources locally
+            (``True``), or from a specified URL (``False``).
+
+        Returns
+        -------
+        jinja2.Template
+            Template where the plot is created.
+        """
+
+        # based on: http://stackoverflow.com/a/6196098
+        env = Environment(loader=FileSystemLoader(TEMPLATES))
+        return env.get_template('empress-template.html')
+
+    def _scavenge_emperor(self):
+        self._emperor = Emperor(self.ordination, self.samples,
+                                remote='./emperor-resources')
+        self._emperor.width = '48vw'
+        self._emperor.height = '100vh; float: right'
+
+        html = self._emperor.make_emperor(standalone=True)
+        html = html.split('\n')
+
+        emperor_base_dependencies = html[6]
+
+        # line 14 is where the CSS includes start
+        style = '\n'.join([line.strip().replace("'", '').replace(',', '')
+                           for line in html[14:20]])
+
+        # main divs for emperor
+        emperor_div = '\n'.join(html[39:44])
+
+        # main js script
+        emperor_require_logic = '\n'.join(html[45:-3])
+
+        emperor_require_logic = emperor_require_logic.replace(
+            '/*__select_callback__*/', SELECTION_CALLBACK)
+
+        emperor_data = {
+            'emperor_div': emperor_div,
+            'emperor_require_logic': emperor_require_logic,
+            'emperor_style': style,
+            'emperor_base_dependencies': emperor_base_dependencies,
+            'emperor_classes': 'combined-plot-container'
+        }
+
+        return emperor_data
+
+
+SELECTION_CALLBACK = """ var colorGroups = {}, color;
+for(var i=0; i < samples.length; i++) {
+  color = samples[i].material.color.getHexString();
+  if (colorGroups[color] === undefined) {
+    colorGroups[color] = [];
+  }
+  colorGroups[color].push(samples[i].name);
+}
+empress.colorSampleGroups(colorGroups);
+
+// 3 seconds before resetting
+setTimeout(function(){
+  empress.resetTree();
+  empress.drawTree();
+
+  samples.forEach(function(sample) {
+    sample.material.emissive.set(0x000000);
+  })
+
+  plotView.needsUpdate = true;
+}, 4000);
+"""

--- a/empress/plugin_setup.py
+++ b/empress/plugin_setup.py
@@ -9,7 +9,7 @@
 
 from ._plot import plot
 
-from qiime2.plugin import Plugin, Metadata, Bool, Citations
+from qiime2.plugin import Plugin, Metadata, Bool, Citations, Int, Range
 from q2_types.tree import Phylogeny, Rooted
 from q2_types.feature_table import FeatureTable, Frequency
 from q2_types.ordination import PCoAResults
@@ -40,7 +40,8 @@ plugin.visualizers.register_function(
         'sample_metadata': Metadata,
         'feature_metadata': Metadata,
         'ignore_missing_samples': Bool,
-        'filter_missing_features': Bool
+        'filter_missing_features': Bool,
+        'number_of_features': Int % Range(1, None)
     },
     input_descriptions={
         'tree': 'The phylogenetic tree to visualize.',
@@ -83,6 +84,13 @@ plugin.visualizers.register_function(
             'at least one feature in the table is also present as a tip in '
             'the tree.'
         ),
+        'number_of_features': 'The number of most important features '
+                              '(arrows) to display in the ordination.'
+                              ' "Importance" is calculated for each feature '
+                              'based on the vector’s magnitude '
+                              '(euclidean distance from origin). Note, this '
+                              'parameter is only honored when a biplot is '
+                              'inputed.',
     },
     name='Visualize and Explore Phylogenies with Empress',
     description=(

--- a/empress/plugin_setup.py
+++ b/empress/plugin_setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2019, QIIME 2 development team.
+# Copyright (c) 2016-2019, empress development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -44,12 +44,13 @@ plugin.visualizers.register_function(
     },
     input_descriptions={
         'tree': 'The phylogenetic tree to visualize.',
-        'feature_table': 'A table containing the abundances of features within'
-                         ' samples. This information allows us to decorate the'
-                         ' phylogeny by sample metadata. It\'s expected that '
-                         ' all features in the table are also present as '
-                         'tips in the tree, and that all samples in the table'
-                         ' are also present in the sample metadata file.',
+        'feature_table': 'A table containing the abundances of features '
+                         'within samples. This information allows us to '
+                         'decorate the phylogeny by sample metadata. It\'s '
+                         'expected that all features in the table are also '
+                         'present as tips in the tree, and that all samples '
+                         'in the table are also present in the sample '
+                         'metadata file.',
         'pcoa': 'Principal coordinates matrix to display simultaneously with '
                 'the phylogenetic tree.'
     },

--- a/empress/plugin_setup.py
+++ b/empress/plugin_setup.py
@@ -12,6 +12,7 @@ from ._plot import plot
 from qiime2.plugin import Plugin, Metadata, Bool, Citations
 from q2_types.tree import Phylogeny, Rooted
 from q2_types.feature_table import FeatureTable, Frequency
+from q2_types.ordination import PCoAResults
 
 import pkg_resources
 __version__ = pkg_resources.get_distribution('empress').version  # noqa
@@ -32,7 +33,8 @@ plugin.visualizers.register_function(
     function=plot,
     inputs={
         'tree': Phylogeny[Rooted],
-        'feature_table': FeatureTable[Frequency]
+        'feature_table': FeatureTable[Frequency],
+        'pcoa': PCoAResults,
     },
     parameters={
         'sample_metadata': Metadata,
@@ -42,13 +44,14 @@ plugin.visualizers.register_function(
     },
     input_descriptions={
         'tree': 'The phylogenetic tree to visualize.',
-        'feature_table': (
-            'A table containing the abundances of features within samples. '
-            'This information allows us to decorate the phylogeny by '
-            "sample metadata. It's expected that all features in the table "
-            'are also present as tips in the tree, and that all samples in '
-            'the table are also present in the sample metadata file.'
-        )
+        'feature_table': 'A table containing the abundances of features within'
+                         ' samples. This information allows us to decorate the'
+                         ' phylogeny by sample metadata. It\'s expected that '
+                         ' all features in the table are also present as '
+                         'tips in the tree, and that all samples in the table'
+                         ' are also present in the sample metadata file.',
+        'pcoa': 'Principal coordinates matrix to display simultaneously with '
+                'the phylogenetic tree.'
     },
     parameter_descriptions={
         'sample_metadata': (

--- a/empress/support_files/css/empress.css
+++ b/empress/support_files/css/empress.css
@@ -356,19 +356,6 @@ label:hover .tooltip {
     left: 0vw;
 }
 
-canvas {
-    width: 100vw;
-    height: 100vh;
-}
-
-.tree-surface {
-    position: fixed;
-    top: 0vh;
-    left: 0vw;
-    width: 100vw;
-    height: 100vw;
-}
-
 /* referenced from  https://webglfundamentals.org/webgl/lessons/webgl-text-html.html*/
 .container {
     position: absolute;
@@ -383,6 +370,14 @@ canvas {
     overflow: hidden;
     width: 100vw;
     height: 100vh;
+}
+
+/* This class is added to container and tree-container to keep empress on the
+ * left-hand-side of the screen when combined with Emperor
+ */
+.combined-plot-container {
+  width: 50vw !important;
+  float: left;
 }
 
 #dvicontainer {
@@ -432,18 +427,16 @@ canvas {
 /* control panel */
 
 #side-panel {
-    position: fixed;
-    top: 0vh;
-    left: 100vw;
-    transform: translateX(-100%);
+    position: absolute;
+    top: 0px;
+    right: 0px;
     width: 450px;
 }
 
 #show-ctrl {
-    position: fixed;
-    top: 0vh;
-    left: 100vw;
-    transform: translateX(-100%);
+    position: absolute;
+    top: 0px;
+    right: 0px;
     opacity: 0.5;
     background-color: #777;
 }

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -5,7 +5,8 @@ define([
     "VectorOps",
     "CanvasEvents",
     "util",
-], function (Camera, Drawer, Colorer, VectorOps, CanvasEvents, util) {
+    "chroma"
+], function (Camera, Drawer, Colorer, VectorOps, CanvasEvents, util, chroma) {
     // The index position of the color array
     const RED = 0;
     const GREEN = 1;
@@ -586,11 +587,7 @@ define([
             obs = Array.from(observationsPerGroup[group]);
 
             // convert hex string to rgb array
-            var rgb = [
-                parseInt(group.slice(0, 2), 16) / 255,
-                parseInt(group.slice(2, 4), 16) / 255,
-                parseInt(group.slice(4), 16) / 255,
-            ];
+            var rgb = chroma(group).gl().slice(0, 3);
 
             for (var i = 0; i < obs.length; i++) {
                 this._treeData[obs[i]].color = rgb;

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -5,7 +5,7 @@ define([
     "VectorOps",
     "CanvasEvents",
     "util",
-    "chroma"
+    "chroma",
 ], function (Camera, Drawer, Colorer, VectorOps, CanvasEvents, util, chroma) {
     // The index position of the color array
     const RED = 0;

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -544,54 +544,61 @@ define([
      * @param {Array} sID - The sample IDs
      * @param {Array} rgb - The rgb array which defines the color
      */
-    Empress.prototype.colorSampleIDs = function(sIds, rgb) {
-      var tree = this._tree;
-      var obs = this._biom.getObjservationUnionForSamples(sIds);
-      obs = Array.from(this._namesToKeys(obs));
-      obs = this._projectObservations({'samples': new Set(obs)});
-      obs = Array.from(obs['samples']);
-
-      for (var i = 0; i < obs.length; i++) {
-          this._treeData[obs[i]].color = rgb;
-      }
-      this.drawTree();
-    };
-
-
-    /**
-     * This method assumes we receive a list of samples and colors from
-     * Emperor then it goes ahead and creates one group per color.
-     */
-    Empress.prototype.colorSampleGroups = function(sampleGroups) {
-      var observationsPerGroup = {}, obs;
-
-      // get a group of observations per color
-      for (var group in sampleGroups) {
-        obs = this._biom.getObjservationUnionForSamples(sampleGroups[group]);
-        observationsPerGroup[group] = new Set(Array.from(this._namesToKeys(obs)));
-      }
-
-      // project to ancestors
-      observationsPerGroup = this._projectObservations(observationsPerGroup);
-
-      for (group in observationsPerGroup) {
-        obs = Array.from(observationsPerGroup[group]);
-
-        // convert hex string to rgb array
-        var rgb = [
-          parseInt(group.slice(0, 2), 16) / 255,
-          parseInt(group.slice(2, 4), 16) / 255,
-          parseInt(group.slice(4), 16) / 255,
-        ];
+    Empress.prototype.colorSampleIDs = function (sIds, rgb) {
+        var tree = this._tree;
+        var obs = this._biom.getObjservationUnionForSamples(sIds);
+        obs = Array.from(this._namesToKeys(obs));
+        obs = this._projectObservations({ samples: new Set(obs) });
+        obs = Array.from(obs.samples);
 
         for (var i = 0; i < obs.length; i++) {
             this._treeData[obs[i]].color = rgb;
         }
-      }
-
-      this.drawTree();
+        this.drawTree();
     };
 
+    /**
+     *
+     * Color the tree by sample groups
+     *
+     * This method assumes we receive a list of samples and colors from
+     * Emperor then it goes ahead and creates one group per color.
+     *
+     * @param {Array} sampleGroups - A list of sample identifiers
+     */
+    Empress.prototype.colorSampleGroups = function (sampleGroups) {
+        var observationsPerGroup = {},
+            obs;
+
+        // get a group of observations per color
+        for (var group in sampleGroups) {
+            obs = this._biom.getObjservationUnionForSamples(
+                sampleGroups[group]
+            );
+            obs = Array.from(this._namesToKeys(obs));
+            observationsPerGroup[group] = new Set(obs);
+        }
+
+        // project to ancestors
+        observationsPerGroup = this._projectObservations(observationsPerGroup);
+
+        for (group in observationsPerGroup) {
+            obs = Array.from(observationsPerGroup[group]);
+
+            // convert hex string to rgb array
+            var rgb = [
+                parseInt(group.slice(0, 2), 16) / 255,
+                parseInt(group.slice(2, 4), 16) / 255,
+                parseInt(group.slice(4), 16) / 255,
+            ];
+
+            for (var i = 0; i < obs.length; i++) {
+                this._treeData[obs[i]].color = rgb;
+            }
+        }
+
+        this.drawTree();
+    };
 
     /**
      * Converts a list of tree node names to their respectives keys in _treeData

--- a/empress/support_files/js/selection-callback.js
+++ b/empress/support_files/js/selection-callback.js
@@ -1,0 +1,23 @@
+// For exclusive use with Emperor
+var colorGroups = {},
+    color;
+for (var i = 0; i < samples.length; i++) {
+    color = samples[i].material.color.getHexString();
+    if (colorGroups[color] === undefined) {
+        colorGroups[color] = [];
+    }
+    colorGroups[color].push(samples[i].name);
+}
+empress.colorSampleGroups(colorGroups);
+
+// 3 seconds before resetting
+setTimeout(function () {
+    empress.resetTree();
+    empress.drawTree();
+
+    samples.forEach(function (sample) {
+        sample.material.emissive.set(0x000000);
+    });
+
+    plotView.needsUpdate = true;
+}, 4000);

--- a/empress/support_files/js/selection-callback.js
+++ b/empress/support_files/js/selection-callback.js
@@ -4,7 +4,8 @@
  *
  */
 
-// if there's any coloring setup remove it
+// if there's any coloring setup remove it, and re-enable the update button
+sPanel.sUpdateBtn.classList.remove("hidden");
 legend.clearAllLegends();
 empress.resetTree();
 

--- a/empress/support_files/js/selection-callback.js
+++ b/empress/support_files/js/selection-callback.js
@@ -1,4 +1,13 @@
-// For exclusive use with Emperor
+/*
+ *
+ * This File is intended to be used only with Emperor
+ *
+ */
+
+// if there's any coloring setup remove it
+legend.clearAllLegends();
+empress.resetTree();
+
 var colorGroups = {},
     color;
 for (var i = 0; i < samples.length; i++) {

--- a/empress/support_files/templates/empress-template.html
+++ b/empress/support_files/templates/empress-template.html
@@ -2,33 +2,39 @@
 <html lang="en">
   <head>
     <title>Empress</title>
-    <link rel='stylesheet' type="text/css"
-      href='{{ base_url }}/css/empress.css'>
+    <link rel='stylesheet' type="text/css" href='{{ base_url }}/css/empress.css'>
+    {{ emperor_style }}
+
     <script src='{{ base_url }}/vendor/require-2.1.22.min.js'></script>
+    {{ emperor_base_dependencies }}
   </head>
   <body>
 
+  <div>
     <!-- The tree -->
-    <div id="tree-container">
-      <div class="container">
+    <div id="tree-container" class="{{ emperor_classes }}">
+      <div class="container {{ emperor_classes }}">
         <canvas class="tree-surface" id="tree-surface">
             Your browser does not support HTML5
         </canvas>
         <div id="tip-label-container"></div>
         <div id="node-label-container"></div>
         <div class="square"></div>
-      </div>
 
-      <!-- Side panel -->
-      <div id="side-panel">
-        {% include 'side-panel.html'%}
-        {% include 'animate-panel.html' %}
-      </div>
+        <!-- Side panel -->
+        <div id="side-panel">
+          {% include 'side-panel.html'%}
+          {% include 'animate-panel.html' %}
+        </div>
 
-      <!-- show control panel button -->
-      <button id="show-ctrl" title="Show control panel" style="font-size: 10pt;
-                padding: 0 0 3px 3px;" class="hidden">&#9699;</button>
+        <!-- show control panel button -->
+        <button id="show-ctrl" title="Show control panel" style="font-size: 10pt; padding: 0 0 3px 3px;" class="hidden">&#9699;</button>
+
+      </div>
     </div>
+
+    {{ emperor_div }}
+  </div>
 
     <!-- hover box -->
     <div class="hidden" id="hover-box">
@@ -149,6 +155,8 @@
         });
 
         document.getElementById("loading-screen").classList.add("hidden");
+
+        {{ emperor_require_logic }}
     });
   </script>
 </html>

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ with open('README.md') as f:
     long_description = f.read()
 
 base = ["numpy", "scipy", "pandas",
-        "jinja2", "scikit-bio", "biom-format", "iow"]
+        "jinja2", "scikit-bio", "biom-format", "iow", "emperor"]
 test = ["pep8", "flake8", "nose"]
 all_deps = base + test
 

--- a/tests/python/test_core.py
+++ b/tests/python/test_core.py
@@ -1,0 +1,155 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2020, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+import unittest
+import pandas as pd
+import numpy as np
+import skbio
+
+from pandas.util.testing import assert_index_equal
+from os.path import exists
+from shutil import rmtree
+
+from empress.core import Empress
+from bp import parse_newick
+
+
+class TestCore(unittest.TestCase):
+    def setUp(self):
+        self.tree = parse_newick('(((a:1,e:2):1,b:2)g:1,(:1,d:3)h:2):1;')
+        # Test table/metadata (mostly) adapted from Qurro:
+        # the table is transposed to match QIIME2's expectation
+        self.table = pd.DataFrame(
+            {
+                "Sample1": [1, 2, 0, 4],
+                "Sample2": [8, 7, 0, 5],
+                "Sample3": [1, 0, 0, 0],
+                "Sample4": [0, 0, 0, 0]
+            },
+            index=["a", "b", "e", "d"]
+        ).T
+        self.sample_metadata = pd.DataFrame(
+            {
+                "Metadata1": [0, 0, 0, 1],
+                "Metadata2": [0, 0, 0, 0],
+                "Metadata3": [1, 2, 3, 4],
+                "Metadata4": ["abc", "def", "ghi", "jkl"]
+            },
+            index=list(self.table.index)
+        )
+
+        eigvals = pd.Series(np.array([0.50, 0.25, 0.25]),
+                            index=['PC1', 'PC2', 'PC3'])
+        samples = np.array([[0.1, 0.2, 0.3],
+                            [0.2, 0.3, 0.4],
+                            [0.3, 0.4, 0.5],
+                            [0.4, 0.5, 0.6]])
+        proportion_explained = pd.Series([15.5, 12.2, 8.8],
+                                         index=['PC1', 'PC2', 'PC3'])
+        samples_df = pd.DataFrame(samples,
+                                  index=['Sample1', 'Sample2', 'Sample3',
+                                         'Sample4'],
+                                  columns=['PC1', 'PC2', 'PC3'])
+        self.pcoa = skbio.OrdinationResults(
+                'PCoA',
+                'Principal Coordinate Analysis',
+                eigvals,
+                samples_df,
+                proportion_explained=proportion_explained)
+
+        self.files_to_remove = []
+
+    def tearDown(self):
+        for path in self.files_to_remove:
+            if exists(path):
+                rmtree(path)
+
+    def test_init(self):
+        viz = Empress(self.tree, self.table, self.sample_metadata)
+
+        self.assertEqual(viz.base_url, './')
+        self.assertEqual(viz._bp_tree, [1, 1, 1, 1, 0, 1, 0, 0, 1, 0, 0, 1, 1,
+                                        0, 1, 0, 0, 0])
+
+        self.fail('Test some key aspects of these objects')
+        # self.assertEqual(self.table, None)
+        # self.assertEqual(self.tree, None)
+        # self.assertEqual(self.samples, None)
+
+    def test_init_with_ordination(self):
+        viz = Empress(self.tree, self.table, self.sample_metadata,
+                      ordination=self.pcoa)
+
+
+        assert_index_equal(viz.ordination.samples.index,
+                           self.pcoa.samples.index)
+
+        self.fail('Validate other aspects')
+
+    def test_init_feature_metadata_warning(self):
+
+        with self.assertWarnsRegex(UserWarning, 'Feature metadata is currently'
+                                   ' not supported'):
+            Empress(self.tree, self.table, self.sample_metadata,
+                    feature_metadata=self.sample_metadata.copy())
+
+    def test_copy_support_files_use_base(self):
+        local_path = './some-local-path/'
+
+        viz = Empress(self.tree, self.table, self.sample_metadata,
+                      resource_path=local_path)
+        self.assertEqual(viz.base_url, local_path)
+
+        viz.copy_support_files()
+
+        self.assertTrue(exists(local_path))
+
+        self.files_to_remove.append(local_path)
+
+    def test_copy_support_files_use_target(self):
+        local_path = './other-local-path/'
+
+        viz = Empress(self.tree, self.table, self.sample_metadata,
+                      resource_path=local_path)
+        self.assertEqual(viz.base_url, local_path)
+
+        viz.copy_support_files(target='./something-else')
+
+        self.assertTrue(exists('./something-else'))
+
+        self.files_to_remove.append(local_path)
+        self.files_to_remove.append('./something-else')
+
+    def test_to_dict(self):
+        viz = Empress(self.tree, self.table, self.sample_metadata)
+        obs = viz._to_dict()
+
+        self.fail('Write real tests for other attributes')
+        self.assertTrue(obs['emperor_div'].startswith('<div>..'))
+        self.assertTrue(obs['emperor_require_logic'].startswith('<div>..'))
+        self.assertTrue(obs['emperor_style'].startswith('<div>..'))
+        self.assertTrue(obs['emperor_base_dependencies'].startswith('<div>..'))
+        self.assertTrue(obs['emperor_classes'], 'combined-plot-container')
+
+    def test_to_dict_with_emperor(self):
+        viz = Empress(self.tree, self.table, self.sample_metadata,
+                      ordination=self.pcoa)
+        obs = viz._to_dict()
+
+        self.fail('Write real tests for other attributes')
+        self.assertTrue(obs['emperor_div'].startswith('<div>..'))
+        self.assertTrue(obs['emperor_require_logic'].startswith('<div>..'))
+        self.assertTrue(obs['emperor_style'].startswith('<div>..'))
+        self.assertTrue(obs['emperor_base_dependencies'].startswith('<div>..'))
+        self.assertTrue(obs['emperor_classes'], 'combined-plot-container')
+
+        self.assertEquals(obs._emperor.width, '48vw')
+        self.assertEquals(obs._emperor.width, '100vh; float: right;')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_core.py
+++ b/tests/python/test_core.py
@@ -10,7 +10,7 @@ import pandas as pd
 import numpy as np
 import skbio
 
-from pandas.util.testing import assert_index_equal
+from pandas.util.testing import assert_index_equal, assert_frame_equal
 from os.path import exists
 from shutil import rmtree
 
@@ -75,15 +75,25 @@ class TestCore(unittest.TestCase):
         self.assertEqual(viz._bp_tree, [1, 1, 1, 1, 0, 1, 0, 0, 1, 0, 0, 1, 1,
                                         0, 1, 0, 0, 0])
 
-        self.fail('Test some key aspects of these objects')
-        # self.assertEqual(self.table, None)
-        # self.assertEqual(self.tree, None)
-        # self.assertEqual(self.samples, None)
+        names = ['a', 'e', 'EmpressNode0', 'b', 'g', 'EmpressNode1', 'd', 'h',
+                 'EmpressNode2']
+        for i, node in enumerate(viz.tree.postorder()):
+            self.assertEqual(node.name, names[i])
+
+        # table should be unchanged and be a different id instance
+        assert_frame_equal(self.table, viz.table.T)
+        self.assertNotEqual(id(self.table), id(viz.table))
+
+        # sample metadata should be unchanged and be a different id instance
+        assert_frame_equal(self.sample_metadata, viz.samples)
+        self.assertNotEqual(id(self.sample_metadata), id(viz.samples))
+
+        self.assertIsNone(viz.features)
+        self.assertIsNone(viz.ordination)
 
     def test_init_with_ordination(self):
         viz = Empress(self.tree, self.table, self.sample_metadata,
                       ordination=self.pcoa)
-
 
         assert_index_equal(viz.ordination.samples.index,
                            self.pcoa.samples.index)

--- a/tests/python/test_core.py
+++ b/tests/python/test_core.py
@@ -11,7 +11,7 @@ import numpy as np
 import skbio
 
 from skbio.util import assert_ordination_results_equal
-from pandas.util.testing import assert_index_equal, assert_frame_equal
+from pandas.util.testing import assert_frame_equal
 from os.path import exists
 from shutil import rmtree
 
@@ -116,9 +116,9 @@ class TestCore(unittest.TestCase):
 
         self.assertIsNone(viz.features)
 
-        assert_ordination_results_equal(viz.ordination.samples, self.pcoa)
+        assert_ordination_results_equal(viz.ordination, self.pcoa)
 
-        # emperor is instantiated as needed
+        # emperor is instantiated as needed but not yet setup
         self.assertTrue(isinstance(viz._emperor, Emperor))
 
     def test_init_feature_metadata_warning(self):

--- a/tests/python/test_core.py
+++ b/tests/python/test_core.py
@@ -158,28 +158,182 @@ class TestCore(unittest.TestCase):
     def test_to_dict(self):
         viz = Empress(self.tree, self.table, self.sample_metadata)
         obs = viz._to_dict()
-
-        self.fail('Write real tests for other attributes')
-        self.assertTrue(obs['emperor_div'].startswith('<div>..'))
-        self.assertTrue(obs['emperor_require_logic'].startswith('<div>..'))
-        self.assertTrue(obs['emperor_style'].startswith('<div>..'))
-        self.assertTrue(obs['emperor_base_dependencies'].startswith('<div>..'))
-        self.assertTrue(obs['emperor_classes'], 'combined-plot-container')
+        self.assertEqual(obs, DICT_A)
 
     def test_to_dict_with_emperor(self):
         viz = Empress(self.tree, self.table, self.sample_metadata,
                       ordination=self.pcoa)
         obs = viz._to_dict()
 
-        self.fail('Write real tests for other attributes')
-        self.assertTrue(obs['emperor_div'].startswith('<div>..'))
-        self.assertTrue(obs['emperor_require_logic'].startswith('<div>..'))
-        self.assertTrue(obs['emperor_style'].startswith('<div>..'))
-        self.assertTrue(obs['emperor_base_dependencies'].startswith('<div>..'))
+        self.assertEqual(viz._emperor.width, '48vw')
+        self.assertEqual(viz._emperor.height, '100vh; float: right')
+
+        # we test key by key so we can do "general" checks on the emperor
+        # values, this helps with tests not breaking if any character changes
+        # in # Emperor
+        for key, value in obs.items():
+            if not key.startswith('emperor_'):
+                self.assertEqual(obs[key], DICT_A[key])
+
+        exp = "    <div id='emperor-notebook"
+        self.assertTrue(obs['emperor_div'].startswith(exp))
+
+        exp = "// When running in the Jupyter"
+        self.assertTrue(obs['emperor_require_logic'].startswith(exp))
+
+        exp = "}); // END REQUIRE.JS block"
+        self.assertTrue(obs['emperor_require_logic'].endswith(exp))
+
+        exp = '<link id="emperor-css" rel="stylesheet"'
+        self.assertTrue(obs['emperor_style'].startswith(exp))
+
+        exp = "vendor/js/jquery-"
+        self.assertEqual(obs['emperor_base_dependencies'].count(exp), 1)
+
         self.assertTrue(obs['emperor_classes'], 'combined-plot-container')
 
-        self.assertEquals(obs._emperor.width, '48vw')
-        self.assertEquals(obs._emperor.width, '100vh; float: right;')
+
+# How data should look like when converted to a dict
+DICT_A = {'base_url': './support_files',
+          'default_layout': 'Unrooted',
+          'emperor_base_dependencies': '',
+          'emperor_classes': '',
+          'emperor_div': '',
+          'emperor_require_logic': '',
+          'emperor_style': '',
+          'layout_to_coordsuffix': {'Rectangular': 'r', 'Unrooted': '2'},
+          'names': ['EmpressNode2',
+                    'g',
+                    'EmpressNode0',
+                    'a',
+                    'e',
+                    'b',
+                    'h',
+                    'EmpressNode1',
+                    'd'],
+          'names_to_keys': {'EmpressNode0': [3],
+                            'EmpressNode1': [6],
+                            'EmpressNode2': [9],
+                            'a': [1],
+                            'b': [4],
+                            'd': [7],
+                            'e': [2],
+                            'g': [5],
+                            'h': [8]},
+          'obs_data': {'Sample1': ['a', 'b', 'd'],
+                       'Sample2': ['a', 'b', 'd'],
+                       'Sample3': ['a'],
+                       'Sample4': []},
+          'sample_data': {'Sample1': {'Metadata1': 0,
+                                      'Metadata2': 0,
+                                      'Metadata3': 1,
+                                      'Metadata4': 'abc'},
+                          'Sample2': {'Metadata1': 0,
+                                      'Metadata2': 0,
+                                      'Metadata3': 2,
+                                      'Metadata4': 'def'},
+                          'Sample3': {'Metadata1': 0,
+                                      'Metadata2': 0,
+                                      'Metadata3': 3,
+                                      'Metadata4': 'ghi'},
+                          'Sample4': {'Metadata1': 1,
+                                      'Metadata2': 0,
+                                      'Metadata3': 4,
+                                      'Metadata4': 'jkl'}},
+          'sample_data_type': {'Metadata1': 'n',
+                               'Metadata2': 'n',
+                               'Metadata3': 'n',
+                               'Metadata4': 'o'},
+          'tree': [1, 1, 1, 1, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 1, 0, 0, 0],
+          'tree_data': {1: {'color': [0.75, 0.75, 0.75],
+                            'name': 'a',
+                            'sampVal': 1,
+                            'single_samp': False,
+                            'visible': True,
+                            'x2': -82.19088834200284,
+                            'xr': 2412.0,
+                            'y2': 1568.2955749395592,
+                            'yr': -2386.875},
+                        2: {'color': [0.75, 0.75, 0.75],
+                            'name': 'e',
+                            'sampVal': 1,
+                            'single_samp': False,
+                            'visible': True,
+                            'x2': 948.7236134182863,
+                            'xr': 3216.0,
+                            'y2': 2108.2845722271436,
+                            'yr': -1381.875},
+                        3: {'color': [0.75, 0.75, 0.75],
+                            'highestchildyr': -1381.875,
+                            'lowestchildyr': -2386.875,
+                            'name': 'EmpressNode0',
+                            'sampVal': 1,
+                            'single_samp': False,
+                            'visible': True,
+                            'x2': 295.3117872853636,
+                            'xr': 1608.0,
+                            'y2': 1102.1185942229504,
+                            'yr': -1884.375},
+                        4: {'color': [0.75, 0.75, 0.75],
+                            'name': 'b',
+                            'sampVal': 1,
+                            'single_samp': False,
+                            'visible': True,
+                            'x2': 1485.5419815224768,
+                            'xr': 2412.0,
+                            'y2': 192.57380029925002,
+                            'yr': -376.875},
+                        5: {'color': [0.75, 0.75, 0.75],
+                            'highestchildyr': -376.875,
+                            'lowestchildyr': -1884.375,
+                            'name': 'g',
+                            'sampVal': 1,
+                            'single_samp': False,
+                            'visible': True,
+                            'x2': 326.7059130664611,
+                            'xr': 804.0,
+                            'y2': 503.08298900209684,
+                            'yr': -1130.625},
+                        6: {'color': [0.75, 0.75, 0.75],
+                            'name': 'EmpressNode1',
+                            'sampVal': 1,
+                            'single_samp': False,
+                            'visible': True,
+                            'x2': -622.0177003518252,
+                            'xr': 2412.0,
+                            'y2': -1605.201583225047,
+                            'yr': 628.125},
+                        7: {'color': [0.75, 0.75, 0.75],
+                            'name': 'd',
+                            'sampVal': 1,
+                            'single_samp': False,
+                            'visible': True,
+                            'x2': -2333.458018477523,
+                            'xr': 4020.0,
+                            'y2': -1651.0752884434787,
+                            'yr': 1633.125},
+                        8: {'color': [0.75, 0.75, 0.75],
+                            'highestchildyr': 1633.125,
+                            'lowestchildyr': 628.125,
+                            'name': 'h',
+                            'sampVal': 1,
+                            'single_samp': False,
+                            'visible': True,
+                            'x2': -653.4118261329227,
+                            'xr': 1608.0,
+                            'y2': -1006.1659780041933,
+                            'yr': 1130.625},
+                        9: {'color': [0.75, 0.75, 0.75],
+                            'highestchildyr': 1130.625,
+                            'lowestchildyr': -1130.625,
+                            'name': 'EmpressNode2',
+                            'sampVal': 1,
+                            'single_samp': False,
+                            'visible': True,
+                            'x2': 0.0,
+                            'xr': 0.0,
+                            'y2': 0.0,
+                            'yr': 0.0}}}
 
 
 if __name__ == "__main__":

--- a/tests/python/test_core.py
+++ b/tests/python/test_core.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2020, QIIME 2 development team.
+# Copyright (c) 2016-2020, empress development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/tests/python/test_core.py
+++ b/tests/python/test_core.py
@@ -168,6 +168,10 @@ class TestCore(unittest.TestCase):
         self.assertEqual(viz._emperor.width, '48vw')
         self.assertEqual(viz._emperor.height, '100vh; float: right')
 
+        self.assertEqual(viz._emperor.settings['axes']['axesColor'], 'black')
+        self.assertEqual(viz._emperor.settings['axes']['backgroundColor'],
+                         'white')
+
         # we test key by key so we can do "general" checks on the emperor
         # values, this helps with tests not breaking if any character changes
         # in # Emperor

--- a/tests/python/test_integration.py
+++ b/tests/python/test_integration.py
@@ -1,8 +1,9 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2018--, empress development team.
+# Copyright (c) 2016-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
+# The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 import os
 import unittest

--- a/tests/python/test_integration.py
+++ b/tests/python/test_integration.py
@@ -52,7 +52,9 @@ class TestIntegration(TestPluginBase):
 
     def test_execution(self):
         """Just checks that the visualizer at least runs without errors."""
-        self.result = self.plot(self.tree, self.table, self.md, self.fmd)
+        self.result = self.plot(tree=self.tree, feature_table=self.table,
+                                sample_metadata=self.md,
+                                feature_metadata=self.fmd)
         self.assertIsInstance(self.result, Results)
         self.assertIsInstance(self.result.visualization, Visualization)
         # TODO check details of viz more carefully (likely by digging into the

--- a/tests/python/test_integration.py
+++ b/tests/python/test_integration.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2020, QIIME 2 development team.
+# Copyright (c) 2016-2020, empress development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/tests/python/test_tools.py
+++ b/tests/python/test_tools.py
@@ -1,8 +1,9 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2018--, empress development team.
+# Copyright (c) 2016-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
+# The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 import unittest
 import pandas as pd

--- a/tests/python/test_tools.py
+++ b/tests/python/test_tools.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2020, QIIME 2 development team.
+# Copyright (c) 2016-2020, empress development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #


### PR DESCRIPTION
This PR moves over the code from _plot.py into a new class `Empress`. In addition this allows support for visualizing ordinations and phylogenies simultaneously. Here's an animated gif of this working with brush selection (related to https://github.com/biocore/emperor/pull/766).

![empress-pr](https://user-images.githubusercontent.com/375307/84715877-a3cd9a00-af26-11ea-8e6d-0bcd74f34fa2.gif)

The example above shows how selecting a group of samples of different colors shows the unique branches per color (similar to UniFrac comparing groups). When a single sample or group is selected, all the features for that group are highlighted in Empress.

`qiime empress plot` now accepts an optional ordination object.
The majority of the code for the Empress class was inspired by the Emperor object.