### PR TITLE
BUG: Problem updating color in circular layout

### DIFF
--- a/empress/support_files/js/side-panel-handler.js
+++ b/empress/support_files/js/side-panel-handler.js
@@ -186,7 +186,7 @@ define(["underscore", "Colorer"], function (_, Colorer) {
         // color tree
         this[colorMethodName]();
 
-        var lWidth = lwInput.value;
+        var lWidth = parseInt(lwInput.value);
         if (lWidth !== 1) {
             this.empress.thickenSameSampleLines(lWidth - 1);
         }


### PR DESCRIPTION
Setting the color and switching between layouts would work just fine.
However, setting the color once in the circular layout would make the
browser tab crash. Seems to be related to to the line width not being parsed
correctly.