### PR TITLE
STY/BUG: Fix an issue with dropdown menus and rename IDs

### DIFF
--- a/empress/support_files/css/empress.css
+++ b/empress/support_files/css/empress.css
@@ -58,6 +58,8 @@ select {
     -ms-appearance: none;
     appearance: none;
     padding-right: 30px;
+    /* ensures other elements are visible if there are long column names */
+    width: 160px;
 }
 
 select::-ms-expand {

--- a/empress/support_files/js/canvas-events.js
+++ b/empress/support_files/js/canvas-events.js
@@ -198,14 +198,14 @@ define(["glMatrix", "SelectedNodeMenu"], function (gl, SelectedNodeMenu) {
         var searchBtn = this.quickSearchBtn;
 
         var createClickEvent = function (e) {
-            var nodeId = this.id;
+            var nodeName = this.id;
 
             // set text of quick-search to match suggested word
-            quickSearchBar.value = nodeId;
-            quickSearchBar.innerHTML = nodeId;
+            quickSearchBar.value = nodeName;
+            quickSearchBar.innerHTML = nodeName;
 
             // show the selected node menu
-            scope.placeNodeSelectionMenu(nodeId);
+            scope.placeNodeSelectionMenu(nodeName);
 
             // clear possible words menu
             removeSuggestionMenu();
@@ -308,29 +308,30 @@ define(["glMatrix", "SelectedNodeMenu"], function (gl, SelectedNodeMenu) {
          * click event for quickSearchBtn
          */
         var search = function () {
-            var nodeId = quickSearchBar.value;
-            scope.placeNodeSelectionMenu(nodeId);
+            var nodeName = quickSearchBar.value;
+            scope.placeNodeSelectionMenu(nodeName);
         };
         searchBtn.onclick = search;
     };
 
     /**
-     * Creates a node selection menu box for nodeId. If nodeId does
+     * Creates a node selection menu box for nodeName. If nodeName does
      * not exist, then this this method will make the background color of the
      * quick search bar red.
      * This method is call from the both the quick search btn and when the user
      * clicks on the canvas.
      *
-     * @param{String} nodeId The node ID to make a node selection menu box for.
+     * @param{String} nodeName The node name to make a node selection menu box
+     * for.
      * @param{Boolean} moveTree If true, then this method will move the viewing
      *                          window of the tree to the node.
      */
     CanvasEvents.prototype.placeNodeSelectionMenu = function (
-        nodeId,
+        nodeName,
         moveTree = true
     ) {
         // multiple nodes can have the same name
-        var idList = this.empress._nameToKeys[nodeId];
+        var idList = this.empress._nameToKeys[nodeName];
 
         if (idList !== undefined) {
             // get first node

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -128,7 +128,7 @@ define([
 
         /**
          * @type{Object}
-         * Feature metadata: keys are tree node IDs, and values are objects
+         * Feature metadata: keys are tree node names, and values are objects
          * mapping feature metadata column names to the metadata value for that
          * feature. We split this up into tip and internal node feature
          * metadata objects.

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -847,13 +847,13 @@ define([
 
         var uniqueValueToFeatures = {};
         _.each(fmObjs, function (mObj) {
-            _.mapObject(mObj, function (fmRow, tipID) {
+            _.mapObject(mObj, function (fmRow, nodeID) {
                 // This is loosely based on how BIOMTable.getObsBy() works.
                 var fmVal = fmRow[cat];
                 if (_.has(uniqueValueToFeatures, fmVal)) {
-                    uniqueValueToFeatures[fmVal].push(tipID);
+                    uniqueValueToFeatures[fmVal].push(nodeID);
                 } else {
-                    uniqueValueToFeatures[fmVal] = [tipID];
+                    uniqueValueToFeatures[fmVal] = [nodeID];
                 }
             });
         });

--- a/empress/support_files/js/select-node-menu.js
+++ b/empress/support_files/js/select-node-menu.js
@@ -12,7 +12,7 @@ define(["underscore", "util"], function (_, util) {
         this.box = document.getElementById("menu-box");
         this.sel = document.getElementById("menu-select");
         this.addBtn = document.getElementById("menu-add-btn");
-        this.nodeIdLabel = document.getElementById("menu-box-node-id");
+        this.nodeNameLabel = document.getElementById("menu-box-node-id");
         this.notes = document.getElementById("menu-box-notes");
         this.warning = document.getElementById("menu-box-warning");
         this.fmTable = document.getElementById("menu-fm-table");
@@ -182,7 +182,7 @@ define(["underscore", "util"], function (_, util) {
         var node = emp._treeData[nodeKeys[0]];
         var name = node.name;
 
-        this.nodeIdLabel.textContent = "ID: " + node.name;
+        this.nodeNameLabel.textContent = "Name: " + node.name;
 
         this.notes.textContent = "";
         this.warning.textContent = "";

--- a/empress/support_files/js/select-node-menu.js
+++ b/empress/support_files/js/select-node-menu.js
@@ -272,7 +272,7 @@ define(["underscore", "util"], function (_, util) {
                 "Warning: " +
                 this.nodeKeys.length +
                 " nodes exist with the " +
-                "above ID.";
+                "above name.";
             isDup = true;
         }
 

--- a/empress/support_files/templates/side-panel.html
+++ b/empress/support_files/templates/side-panel.html
@@ -1,7 +1,7 @@
 <!-- The Header bar -->
 <div id="autocomplete-container">
   <p class="side-header">
-    <input type="text" id="quick-search" placeholder="Search by node ID..."
+    <input type="text" id="quick-search" placeholder="Search by node name..."
            style="flex-grow: 1;">
     <button id="side-header-search-btn" style="flex-grow: 1;">Search</button>
     <button id="hide-ctrl" title="Hide control panel"


### PR DESCRIPTION
Fixes an issue with drop-down menus pushing the label and checkbox in
the sidebar.

Long metadata columns would make the label and checkbox not be visible:

<img width="1679" alt="Screen Shot 2020-06-29 at 1 25 21 PM" src="https://user-images.githubusercontent.com/375307/86058050-19506480-ba15-11ea-89e9-bf1712c8b117.png">

I fixed this by setting the max width to a known value:

![fixed](https://user-images.githubusercontent.com/375307/86058071-24a39000-ba15-11ea-8202-dc4276bba1e6.gif)


Also replaces "node id" references to be "node name" (note the screenshots above were capture before I put these fixes in).

Fixes #196