### PR TITLE
Add tests for leaf/internal node sample presence

### DIFF
--- a/tests/test-empress.js
+++ b/tests/test-empress.js
@@ -677,5 +677,53 @@ require([
                     1.0e-15
             );
         });
+
+        test("Test computeLeafSamplePresence", function() {
+            var e = this.empress;
+            var fields = e._biom._smCols;
+            var ctData = e.computeLeafSamplePresence("2", fields);
+
+            var lf2presence = {
+                "f1": {"a": 4, "b": 1},
+                "grad": {"1": 1, "2": 2, "3": 2, "4": 0},
+                "traj": {"t1": 2, "t2": 1, "t3": 2, "t4": 0}
+            };
+            deepEqual(ctData, lf2presence);
+        });
+
+        test("Test computeIntSamplePresence", function() {
+            var e = this.empress;
+            e._tree.names_ = ["root", "internal", "1", "internal",
+                              "2", "3", "6"];
+
+            var fieldsMap = {};
+            var fields = e._biom._smCols;
+            for (i = 0; i < fields.length; i++) {
+                field = fields[i];
+                var possibleValues = e._biom.getUniqueSampleValues(field);
+                for (j = 0; j < possibleValues.length; j++) {
+                    var possibleValue = possibleValues[j];
+                    if (!(field in fieldsMap)) fieldsMap[field] = {};
+                    fieldsMap[field][possibleValue] = 0;
+                }
+            }
+
+            var nodeKey = 4;
+            var tips = e.findTips(nodeKey);
+            deepEqual(tips, ["2", "3"]);
+
+            var intersection = e._biom.getObsIDsIntersection(tips);
+            var diff = e._biom.getObsIDsDifference(tips);
+            var samples = e._biom.getSamplesByObservations(intersection);
+
+            var ctData = e.computeIntSamplePresence(samples, fields, fieldsMap);
+
+            var int4presence = {
+                "f1": {"a": 5, "b": 1},
+                "grad": {"1": 2, "2": 2, "3": 2, "4": 0},
+                "traj": {"t1": 2, "t2": 2, "t3": 2, "t4": 0}
+            };
+            deepEqual(ctData, int4presence);
+        });
     });
 });


### PR DESCRIPTION
Shifted some of the sample presence computation from select-node-menu.js to empress.js and added some tests.