### PR TITLE
Rename a few things in the JS code

### DIFF
--- a/empress/support_files/js/animator.js
+++ b/empress/support_files/js/animator.js
@@ -232,7 +232,7 @@ define(["Colorer", "util"], function (Colorer, util) {
         // draw tree
         this.empress.resetTree();
         this.empress._colorTree(obs, this.cm);
-        this.empress.thickenSameSampleLines(this.lWidth);
+        this.empress.thickenColoredNodes(this.lWidth);
 
         // TODO: hide should be taken care of in empress state machine
         this.empress.setNonSampleBranchVisibility(this.hide);

--- a/empress/support_files/js/drawer.js
+++ b/empress/support_files/js/drawer.js
@@ -107,9 +107,9 @@ define(["glMatrix", "Camera"], function (gl, Camera) {
         s.treeVertBuff = c.createBuffer();
         this.treeVertSize = 0;
 
-        // buffer object used to thicken sampleLines
-        s.sampleThickBuff = c.createBuffer();
-        this.sampleThickSize = 0;
+        // buffer object used to thicken node lines
+        s.thickNodeBuff = c.createBuffer();
+        this.thickNodeSize = 0;
 
         // buffer object for tree nodes
         s.nodeVertBuff = c.createBuffer();
@@ -249,21 +249,21 @@ define(["glMatrix", "Camera"], function (gl, Camera) {
      *
      * @param {Array} data The coordinate and color data to fill tree buffer
      */
-    Drawer.prototype.loadTreeBuf = function (data) {
+    Drawer.prototype.loadTreeBuff = function (data) {
         data = new Float32Array(data);
         this.treeVertSize = data.length / 5;
         this.fillBufferData_(this.sProg_.treeVertBuff, data);
     };
 
     /**
-     * Fills the buffer used to thicken sample lines
+     * Fills the buffer used to thicken node lines
      *
-     * @param {Array} data The coordinate and color data to fill sampleThink
+     * @param {Array} data Coordinate and color data to fill the buffer with
      */
-    Drawer.prototype.loadSampleThickBuf = function (data) {
+    Drawer.prototype.loadThickNodeBuff = function (data) {
         data = new Float32Array(data);
-        this.sampleThickSize = data.length / 5;
-        this.fillBufferData_(this.sProg_.sampleThickBuff, data);
+        this.thickNodeSize = data.length / 5;
+        this.fillBufferData_(this.sProg_.thickNodeBuff, data);
     };
 
     /**
@@ -338,8 +338,8 @@ define(["glMatrix", "Camera"], function (gl, Camera) {
         this.bindBuffer(s.treeVertBuff);
         c.drawArrays(c.LINES, 0, this.treeVertSize);
 
-        this.bindBuffer(s.sampleThickBuff);
-        c.drawArrays(c.TRIANGLES, 0, this.sampleThickSize);
+        this.bindBuffer(s.thickNodeBuff);
+        c.drawArrays(c.TRIANGLES, 0, this.thickNodeSize);
     };
 
     /**

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -172,7 +172,7 @@ define([
         /**
          * @type{Number}
          * The (not-yet-scaled) line width used for drawing "thick" lines.
-         * Can be passed as input to this.thickenSameSampleLines().
+         * Can be passed as input to this.thickenColoredNodes().
          */
         this._currentLineWidth = 0;
 
@@ -206,7 +206,7 @@ define([
      * Draws the tree
      */
     Empress.prototype.drawTree = function () {
-        this._drawer.loadTreeBuf(this.getCoords());
+        this._drawer.loadTreeBuff(this.getCoords());
         this._drawer.loadNodeBuff(this.getNodeCoords());
         this._drawer.draw();
     };
@@ -742,7 +742,7 @@ define([
      * for Arrays/Objects; see http://jasonjl.me/blog/2014/10/15/javascript.)
      *
      * @param {Array} coords Array containing coordinate + color data, to be
-     *                       passed to Drawer.loadSampleThickBuf().
+     *                       passed to Drawer.loadThickNodeBuff().
      * @param {Object} corners Object with tL, tR, bL, and bR entries (each
      *                         mapping to an array of the format [x, y]
      *                         indicating this position).
@@ -773,7 +773,7 @@ define([
      * bL |-bR---
      *
      * @param {Array} coords  Array containing coordinate + color data, to be
-     *                        passed to Drawer.loadSampleThickBuf().
+     *                        passed to Drawer.loadThickNodeBuff().
      * @param {Number} node   Node index in this._treeData, from which we'll
      *                        retrieve coordinate information.
      * @param {Number} lwScaled Desired line thickness (note that this will be
@@ -819,14 +819,14 @@ define([
      *                    parameter should be the output from
      *                    util.parseAndValidateLineWidth().)
      */
-    Empress.prototype.thickenSameSampleLines = function (lw) {
+    Empress.prototype.thickenColoredNodes = function (lw) {
         // If lw isn't > 0, then we don't thicken colored lines at all --
         // we just leave them at their default width.
         if (lw < 0) {
             // should never happen because util.parseAndValidateLineWidth()
             // should've been called in order to obtain lw, but in case
             // this gets messed up in the future we'll catch it
-            throw "Line width passed to thickenSameSampleLines() is < 0.";
+            throw "Line width passed to thickenColoredNodes() is < 0.";
         } else {
             // Make sure that, even if lw is 0 (i.e. we don't need to
             // thicken the lines), we still set the current line width
@@ -850,7 +850,7 @@ define([
 
         // the coordinates of the tree
         var coords = [];
-        this._drawer.loadSampleThickBuf([]);
+        this._drawer.loadThickNodeBuff([]);
 
         // define these variables so jslint does not complain
         var x1, y1, x2, y2, corners;
@@ -860,7 +860,7 @@ define([
         // drawing the tree in Rectangular layout mode
         if (
             this._currentLayout === "Rectangular" &&
-            this._treeData[tree.size].sampleColored
+            this._treeData[tree.size].isColored
         ) {
             this._addThickVerticalLineCoords(coords, tree.size, lwScaled);
         }
@@ -870,7 +870,7 @@ define([
             var node = i;
             var parent = tree.postorder(tree.parent(tree.postorderselect(i)));
 
-            if (!this._treeData[node].sampleColored) {
+            if (!this._treeData[node].isColored) {
                 continue;
             }
 
@@ -972,7 +972,7 @@ define([
             }
         }
 
-        this._drawer.loadSampleThickBuf(coords);
+        this._drawer.loadThickNodeBuff(coords);
     };
 
     /**
@@ -1038,12 +1038,12 @@ define([
     };
 
     /**
-     * Color the tree using sample data
+     * Color the tree using sample metadata
      *
-     * @param {String} cat The sample category to use
-     * @param {String} color - the Color map to use
+     * @param {String} cat Sample metadata category to use
+     * @param {String} color Color map to use
      *
-     * @return {Object} If there exists at least on group with unique features
+     * @return {Object} If there exists at least one group with unique features
      *                  then an object will be returned that maps groups with
      *                  unique features to a color. If there doesn't exist a
      *                  group with unique features then null will be returned.
@@ -1168,6 +1168,9 @@ define([
         // things -- or at least to rename a lot of these coloring utilities
         // to talk about "groups" rather than "samples", esp. since I think
         // animation has the same problem...
+        // UPDATE: Since .inSample and related stuff will be removed shortly,
+        // this will soon no longer be an issue and this comment block will be
+        // removeable.
         if (method === "tip") {
             obs = this._projectObservations(obs);
         }
@@ -1257,12 +1260,16 @@ define([
     /**
      * Updates the tree based on obs and cm but does not draw a new tree.
      *
-     * Note: The nodes in each sample category should be unique. The behavior of
+     * NOTE: The nodes in each category should be unique. The behavior of
      *       this function is undefined if nodes in each category are not
      *       unique.
      *
-     * @param{Object} obs The mapping from sample category to unique nodes.
-     * @param{Object} cm The mapping from sample category to color.
+     * @param{Object} obs Maps categories to the unique nodes to be colored for
+     *                    each category.
+     * @param{Object} cm Maps categories to the colors to color their nodes
+     *                   with. Colors should be represented as RGB arrays, for
+     *                   example as is done in the color values of the output
+     *                   of Colorer.getMapRGB().
      */
     Empress.prototype._colorTree = function (obs, cm) {
         var categories = util.naturalSort(Object.keys(obs));
@@ -1274,7 +1281,7 @@ define([
             for (var j = 0; j < keys.length; j++) {
                 var key = keys[j];
                 this._treeData[key].color = cm[category];
-                this._treeData[key].sampleColored = true;
+                this._treeData[key].isColored = true;
             }
         }
     };
@@ -1288,10 +1295,10 @@ define([
             var key = keys[i];
             this._treeData[key].color = this.DEFAULT_COLOR;
             this._treeData[key].inSample = false;
-            this._treeData[key].sampleColored = false;
+            this._treeData[key].isColored = false;
             this._treeData[key].visible = true;
         }
-        this._drawer.loadSampleThickBuf([]);
+        this._drawer.loadThickNodeBuff([]);
     };
 
     /**
@@ -1322,9 +1329,9 @@ define([
                 // Adjust the thick-line stuff before calling drawTree() --
                 // this will get the buffer set up before it's actually drawn
                 // in drawTree(). Doing these calls out of order (draw tree,
-                // then call thickenSameSampleLines()) causes the thick-line
+                // then call thickenColoredNodes()) causes the thick-line
                 // stuff to only change whenever the tree is redrawn.
-                this.thickenSameSampleLines(this._currentLineWidth);
+                this.thickenColoredNodes(this._currentLineWidth);
                 // this._drawer.loadNodeBuff(this.getNodeCoords());
                 // this.drawTree();
                 this.centerLayoutAvgPoint();

--- a/empress/support_files/js/side-panel-handler.js
+++ b/empress/support_files/js/side-panel-handler.js
@@ -196,7 +196,7 @@ define(["underscore", "Colorer", "util"], function (_, Colorer, util) {
         this[colorMethodName]();
 
         var lw = util.parseAndValidateLineWidth(lwInput);
-        this.empress.thickenSameSampleLines(lw);
+        this.empress.thickenColoredNodes(lw);
         this.empress.drawTree();
     };
 

--- a/empress/support_files/js/util.js
+++ b/empress/support_files/js/util.js
@@ -172,7 +172,7 @@ define(["underscore"], function (_) {
      *                               these things are checked for here -- we
      *                               only look at the value of this element.
      * @return {Number} Sanitized number that can be used as input to
-     *                  Empress.thickenSameSampleLines().
+     *                  Empress.thickenColoredNodes().
      */
     function parseAndValidateLineWidth(inputEle) {
         if (isValidNumber(inputEle.value)) {

--- a/tests/test-empress.js
+++ b/tests/test-empress.js
@@ -563,7 +563,7 @@ require([
             for (var i = 0; i < keys.length; i++) {
                 var key = keys[i];
                 deepEqual(e._treeData[key].color, e.DEFAULT_COLOR);
-                equal(e._treeData[key].sampleColored, false);
+                equal(e._treeData[key].isColored, false);
             }
         });
 


### PR DESCRIPTION
Closes #186. This doesn't remove `.inSample`, since that is already being removed in #277 anyway.