### PR TITLE
ENH: Focus on node when clicking on an arrow

### DIFF
--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -1495,7 +1495,7 @@ define([
         }
 
         this._events.selectedNodeMenu.clearSelectedNode();
-        this._events.placeNodeSelectionMenu(nodeName, false);
+        this._events.placeNodeSelectionMenu(nodeName, true);
     };
 
     return Empress;


### PR DESCRIPTION
Before, the menu would show but the camera wouldn't refocus.