### PR TITLE
Add settings to ignore absent tips, and not change camera focus on selected tips

### DIFF
--- a/empress/support_files/js/animator.js
+++ b/empress/support_files/js/animator.js
@@ -328,7 +328,8 @@ define(["Colorer", "util"], function (Colorer, util) {
             category = categories[i];
             obs[category] = this.empress._namesToKeys(obs[category]);
         }
-        obs = this.empress._projectObservations(obs);
+        obs = this.empress._projectObservations(obs,
+                                                this.empress.ignoreAbsentTips);
 
         // add non-empty groups to the legend for this frame
         var legend = {};

--- a/empress/support_files/js/animator.js
+++ b/empress/support_files/js/animator.js
@@ -328,8 +328,10 @@ define(["Colorer", "util"], function (Colorer, util) {
             category = categories[i];
             obs[category] = this.empress._namesToKeys(obs[category]);
         }
-        obs = this.empress._projectObservations(obs,
-                                                this.empress.ignoreAbsentTips);
+        obs = this.empress._projectObservations(
+            obs,
+            this.empress.ignoreAbsentTips
+        );
 
         // add non-empty groups to the legend for this frame
         var legend = {};

--- a/empress/support_files/js/canvas-events.js
+++ b/empress/support_files/js/canvas-events.js
@@ -373,7 +373,7 @@ define(["glMatrix", "SelectedNodeMenu"], function (gl, SelectedNodeMenu) {
             // We'll position the camera at whatever the "first" node in
             // nodeKeys is. This is an arbitrary decision, but better than
             // nothing.
-            if (moveTree) {
+            if (moveTree && scope.empress.focusOnSelectedNode) {
                 var nodeToCenterOn = scope.empress._treeData[nodeKeys[0]];
                 scope.drawer.centerCameraOn(
                     scope.empress.getX(nodeToCenterOn),

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -1188,7 +1188,7 @@ define([
         // this will soon no longer be an issue and this comment block will be
         // removeable.
         if (method === "tip") {
-            obs = this._projectObservations(obs);
+            obs = this._projectObservations(obs, false);
         }
 
         // color tree

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -177,6 +177,18 @@ define([
         this._currentLineWidth = 0;
 
         /**
+         * @type{Bool}
+         * Whether the camera is focused on a selected node.
+         */
+        this.focusOnSelectedNode = true;
+
+        /**
+         * @type{Bool}
+         * Whether unrepresented tips are ignored when propagating colors.
+         */
+        this.ignoreAbsentTips = true;
+
+        /**
          * @type{CanvasEvents}
          * Handles user events
          */
@@ -996,7 +1008,7 @@ define([
         }
 
         // project to ancestors
-        observationsPerGroup = this._projectObservations(observationsPerGroup);
+        observationsPerGroup = this._projectObservations(observationsPerGroup, this.ignoreAbsentTips);
 
         for (group in observationsPerGroup) {
             obs = Array.from(observationsPerGroup[group]);
@@ -1063,7 +1075,8 @@ define([
         }
 
         // assign internal nodes to appropriate category based on its children
-        obs = this._projectObservations(obs);
+        obs = this._projectObservations(obs, this.ignoreAbsentTips);
+
         if (Object.keys(obs).length === 0) {
             return null;
         }
@@ -1198,29 +1211,33 @@ define([
      *       returned version of obs.
      *
      * @param {Object} obs Maps categories to a set of observations (i.e. tips)
+     * @param {Bool} ignoreAbsent Wheter absent branches should be ignored
+     * during color propagation.
      * @return {Object} returns A Map with the same group names that maps groups
                         to a set of keys (i.e. tree nodes) that are unique to
                         each group.
      */
-    Empress.prototype._projectObservations = function (obs) {
+    Empress.prototype._projectObservations = function (obs, ignoreAbsent) {
         var tree = this._tree,
             categories = Object.keys(obs),
             notRepresented = new Set(),
             i,
             j;
 
-        // find "non-represented" tips
-        // Note: the following uses postorder traversal
-        for (i = 1; i < tree.size; i++) {
-            if (tree.isleaf(tree.postorderselect(i))) {
-                var represented = false;
-                for (j = 0; j < categories.length; j++) {
-                    if (obs[categories[j]].has(i)) {
-                        represented = true;
-                        break;
+        if (!ignoreAbsent) {
+            // find "non-represented" tips
+            // Note: the following uses postorder traversal
+            for (i = 1; i < tree.size; i++) {
+                if (tree.isleaf(tree.postorderselect(i))) {
+                    var represented = false;
+                    for (j = 0; j < categories.length; j++) {
+                        if (obs[categories[j]].has(i)) {
+                            represented = true;
+                            break;
+                        }
                     }
+                    if (!represented) notRepresented.add(i);
                 }
-                if (!represented) notRepresented.add(i);
             }
         }
 
@@ -1495,7 +1512,7 @@ define([
         }
 
         this._events.selectedNodeMenu.clearSelectedNode();
-        this._events.placeNodeSelectionMenu(nodeName, true);
+        this._events.placeNodeSelectionMenu(nodeName, this.focusOnSelectedNode);
     };
 
     return Empress;

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -1008,7 +1008,10 @@ define([
         }
 
         // project to ancestors
-        observationsPerGroup = this._projectObservations(observationsPerGroup, this.ignoreAbsentTips);
+        observationsPerGroup = this._projectObservations(
+            observationsPerGroup,
+            this.ignoreAbsentTips
+        );
 
         for (group in observationsPerGroup) {
             obs = Array.from(observationsPerGroup[group]);

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -1211,20 +1211,20 @@ define([
      *       returned version of obs.
      *
      * @param {Object} obs Maps categories to a set of observations (i.e. tips)
-     * @param {Bool} ignoreAbsent Wheter absent branches should be ignored
+     * @param {Bool} ignoreAbsentTips Wheter absent tips should be ignored
      * during color propagation.
      * @return {Object} returns A Map with the same group names that maps groups
                         to a set of keys (i.e. tree nodes) that are unique to
                         each group.
      */
-    Empress.prototype._projectObservations = function (obs, ignoreAbsent) {
+    Empress.prototype._projectObservations = function (obs, ignoreAbsentTips) {
         var tree = this._tree,
             categories = Object.keys(obs),
             notRepresented = new Set(),
             i,
             j;
 
-        if (!ignoreAbsent) {
+        if (!ignoreAbsentTips) {
             // find "non-represented" tips
             // Note: the following uses postorder traversal
             for (i = 1; i < tree.size; i++) {

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -1214,7 +1214,7 @@ define([
      *       returned version of obs.
      *
      * @param {Object} obs Maps categories to a set of observations (i.e. tips)
-     * @param {Bool} ignoreAbsentTips Wheter absent tips should be ignored
+     * @param {Bool} ignoreAbsentTips Whether absent tips should be ignored
      * during color propagation.
      * @return {Object} returns A Map with the same group names that maps groups
                         to a set of keys (i.e. tree nodes) that are unique to

--- a/empress/support_files/js/side-panel-handler.js
+++ b/empress/support_files/js/side-panel-handler.js
@@ -16,6 +16,8 @@ define(["underscore", "Colorer", "util"], function (_, Colorer, util) {
      * @constructs SidePanel
      */
     function SidePanel(container, empress, legend) {
+        var scope = this;
+
         // the container for the side menu
         this.container = container;
         this.SIDE_PANEL_ID = container.id;
@@ -41,6 +43,11 @@ define(["underscore", "Colorer", "util"], function (_, Colorer, util) {
         };
         this.absentTipChk.onclick = function () {
             empress.ignoreAbsentTips = this.checked;
+
+            // only update the tree if sample selection is enabled
+            if (scope.sChk.checked) {
+                scope.sUpdateBtn.click();
+            }
         };
 
         // sample GUI components

--- a/empress/support_files/js/side-panel-handler.js
+++ b/empress/support_files/js/side-panel-handler.js
@@ -33,15 +33,15 @@ define(["underscore", "Colorer", "util"], function (_, Colorer, util) {
         // tree properties components
         this.treeNodesChk = document.getElementById("display-nodes-chk");
         this.recenterBtn = document.getElementById("center-tree-btn");
-        this.focusOnNodeChk = document.getElementById('focus-on-node-chk');
-        this.absentTipChk = document.getElementById('absent-tip-chk');
+        this.focusOnNodeChk = document.getElementById("focus-on-node-chk");
+        this.absentTipChk = document.getElementById("absent-tip-chk");
 
-        this.focusOnNodeChk.onclick = function() {
+        this.focusOnNodeChk.onclick = function () {
             empress.focusOnSelectedNode = this.checked;
         };
-        this.absentTipChk.onclick = function() {
+        this.absentTipChk.onclick = function () {
             empress.ignoreAbsentTips = this.checked;
-        }
+        };
 
         // sample GUI components
         this.sChk = document.getElementById("sample-chk");

--- a/empress/support_files/js/side-panel-handler.js
+++ b/empress/support_files/js/side-panel-handler.js
@@ -33,6 +33,15 @@ define(["underscore", "Colorer", "util"], function (_, Colorer, util) {
         // tree properties components
         this.treeNodesChk = document.getElementById("display-nodes-chk");
         this.recenterBtn = document.getElementById("center-tree-btn");
+        this.focusOnNodeChk = document.getElementById('focus-on-node-chk');
+        this.absentTipChk = document.getElementById('absent-tip-chk');
+
+        this.focusOnNodeChk.onclick = function() {
+            empress.focusOnSelectedNode = this.checked;
+        };
+        this.absentTipChk.onclick = function() {
+            empress.ignoreAbsentTips = this.checked;
+        }
 
         // sample GUI components
         this.sChk = document.getElementById("sample-chk");
@@ -370,7 +379,7 @@ define(["underscore", "Colorer", "util"], function (_, Colorer, util) {
         this.sColor.onchange = showUpdateBtn;
         this.sLineWidth.onchange = showUpdateBtn;
 
-        // deterines whether to show features not in samples
+        // determines whether to show features not in samples
         this.sHideChk.onclick = function () {
             scope.empress.setNonSampleBranchVisibility(this.checked);
             scope.empress.drawTree();

--- a/empress/support_files/js/side-panel-handler.js
+++ b/empress/support_files/js/side-panel-handler.js
@@ -16,6 +16,7 @@ define(["underscore", "Colorer", "util"], function (_, Colorer, util) {
      * @constructs SidePanel
      */
     function SidePanel(container, empress, legend) {
+        // used in event closures
         var scope = this;
 
         // the container for the side menu
@@ -77,9 +78,6 @@ define(["underscore", "Colorer", "util"], function (_, Colorer, util) {
 
         // uncheck button
         this.sHideChk.checked = false;
-
-        // used in event closures
-        var scope = this;
 
         // hides the side menu
         var collapse = document.getElementById(this.COLLAPSE_ID);

--- a/empress/support_files/templates/side-panel.html
+++ b/empress/support_files/templates/side-panel.html
@@ -190,4 +190,24 @@
   <p class="side-panel-notes indented">
     Repositions the camera at the center of the tree.
   </p>
+  <p>
+    <label for="focus-on-node-chk">Focus on Selected Nodes?</label>
+    <input id="focus-on-node-chk" type="checkbox" checked="true"
+           class="empress-input">
+  </p>
+  <p class="side-panel-notes indented">
+    If checked, the camera is focused on the node after an id is found via
+    the searchbox, or when an arrow is clicked in a biplot.
+  </p>
+  <p>
+    <label for="absent-tip-chk">Ignore Absent Tips?</label>
+    <input id="absent-tip-chk" type="checkbox" checked="true"
+           class="empress-input">
+  </p>
+  <p class="side-panel-notes indented">
+    If checked, tips not represented in the current sample selection are
+    ignored when propagating the color of a clade. Applies to sample metadata
+    coloring, animations, and sample selections in Emperor.
+  </p>
+
 </div>

--- a/empress/support_files/templates/side-panel.html
+++ b/empress/support_files/templates/side-panel.html
@@ -207,7 +207,9 @@
   <p class="side-panel-notes indented">
     If checked, tips not represented in the current sample selection are
     ignored when propagating the color of a clade. Applies to sample metadata
-    coloring, animations, and sample selections in Emperor.
+    coloring, animations, and sample selections in Emperor. We recommend to
+    change this setting before starting an animation, otherwise this setting
+    might be partially applied.
   </p>
 
 </div>

--- a/tests/test-empress.js
+++ b/tests/test-empress.js
@@ -458,7 +458,7 @@ require([
                 g2: new Set([1]),
                 g3: new Set([6]),
             };
-            var result = this.empress._projectObservations(obs);
+            var result = this.empress._projectObservations(obs, false);
 
             var groups = ["g1", "g2", "g3"];
             for (var i = 0; i < groups.length; i++) {
@@ -482,7 +482,7 @@ require([
                 g1: new Set([2, 3, 4]),
                 g3: new Set([6]),
             };
-            var result = this.empress._projectObservations(obs);
+            var result = this.empress._projectObservations(obs, false);
 
             var groups = ["g1", "g3"];
             for (var i = 0; i < groups.length; i++) {

--- a/tests/test-empress.js
+++ b/tests/test-empress.js
@@ -504,7 +504,51 @@ require([
             var expectedResult = {
                 g1: new Set([1, 2, 3, 4, 5, 6, 7]),
             };
-            var result = this.empress._projectObservations(obs);
+            var result = this.empress._projectObservations(obs, false);
+
+            var groups = ["g1"];
+            for (var i = 0; i < groups.length; i++) {
+                var group = groups[i];
+                var expectedArray = Array.from(expectedResult[group]);
+                var resultArray = util.naturalSort(Array.from(result[group]));
+                deepEqual(resultArray, expectedArray);
+            }
+
+            var columns = Object.keys(result);
+            deepEqual(columns, groups);
+        });
+
+        test("Test _projectObservations ingore absent tips", function () {
+            var obs = {
+                g1: new Set([2]),
+                g2: new Set([6]),
+            };
+            var expectedResult = {
+                g1: new Set([2, 4, 5]),
+                g2: new Set([6]),
+            };
+            var result = this.empress._projectObservations(obs, true);
+
+            var groups = ["g1", "g2"];
+            for (var i = 0; i < groups.length; i++) {
+                var group = groups[i];
+                var expectedArray = Array.from(expectedResult[group]);
+                var resultArray = util.naturalSort(Array.from(result[group]));
+                deepEqual(resultArray, expectedArray);
+            }
+
+            var columns = Object.keys(result);
+            deepEqual(columns, groups);
+        });
+
+        test("Test _projectObservations nothing is absent", function () {
+            var obs = {
+                g1: new Set([1, 2, 3]),
+            };
+            var expectedResult = {
+                g1: new Set([1, 2, 3, 4, 5, 7]),
+            };
+            var result = this.empress._projectObservations(obs, true);
 
             var groups = ["g1"];
             for (var i = 0; i < groups.length; i++) {
@@ -523,7 +567,7 @@ require([
                 g1: new Set([]),
                 g2: new Set([]),
             };
-            var result = this.empress._projectObservations(obs);
+            var result = this.empress._projectObservations(obs, false);
             var expectedResult = [];
             var columns = Object.keys(result);
             deepEqual(columns, expectedResult);


### PR DESCRIPTION
In the gif below, two new settings to control how absent tips are treated in sample coloring, and what to do when selecting a node. 

![setting](https://user-images.githubusercontent.com/375307/88855532-e16d4600-d1a7-11ea-8bc6-b4024c49c415.gif)
