### PR TITLE
Fix a bug with barplot length scaling; abstract and test length-scaling code

### DIFF
--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -1315,7 +1315,7 @@ define([
                 // TODO: verify that this handles negative values properly
                 // and/or support drawing negative values in the opposite
                 // direction as positive ones
-                fm2length[fn] =
+                fm2length[n] =
                     ((fn - valMin) / valRange) * lengthRange +
                     layer.scaleLengthByFMMin;
             });

--- a/empress/support_files/js/util.js
+++ b/empress/support_files/js/util.js
@@ -190,6 +190,92 @@ define(["underscore"], function (_) {
         return min;
     }
 
+    /**
+     * Produces an Object mapping feature metadata values to barplot lengths.
+     *
+     * This code was based on ColorViewController.getScaledColors() in Emperor:
+     * https://github.com/biocore/emperor/blob/b959aed7ffcb9fa3e4d019c6e93a1af3850564d9/emperor/support_files/js/color-view-controller.js#L398
+     *
+     * @param {Array} sortedUniqueValues Array of unique values present in a
+     *                                   feature metadata field. Should have
+     *                                   been sorted using util.naturalSort().
+     *                                   Since these are expected to already be
+     *                                   *unique*, there shouldn't be any
+     *                                   duplicate values in this array.
+     * @param {Number} minLength Minimum length value to use for scaling: the
+     *                           minimum numeric value in sortedUniqueValues
+     *                           will get assigned this length.
+     * @param {Number} maxLength Maximum length value to use for scaling; works
+     *                           analogously to minLength above.
+     * @param {Number} layerNum Number of the barplot layer for which these
+     *                          scaling computations are being done. This
+     *                          will only be used if something goes wrong and
+     *                          this function needs to throw an error message.
+     * @param {String} fieldName Name of the feature metadata field represented
+     *                           by sortedUniqueValues. As with layerNum, this
+     *                           will only be used if this throws an error
+     *                           message.
+     * @return {Object} fm2length Maps the numeric items in sortedUniqueValues
+     *                            to their corresponding barplot lengths.
+     *                            Each length is guaranteed to be within the
+     *                            inclusive range [minLength, maxLength].
+     */
+    function assignBarplotLengths(
+        sortedUniqueValues,
+        minLength,
+        maxLength,
+        layerNum,
+        fieldName
+    ) {
+        var split = splitNumericValues(sortedUniqueValues);
+        if (split.numeric.length < 2) {
+            throw new Error(
+                "Error with scaling lengths in barplot layer " +
+                    layerNum +
+                    ': the feature metadata field "' +
+                    fieldName +
+                    '" has less than 2 unique numeric values.'
+            );
+        }
+        fm2length = {};
+        // Compute the maximum and minimum values in the field to use to
+        // scale length by
+        var nums = _.map(split.numeric, parseFloat);
+        var valMin = _.min(nums);
+        var valMax = _.max(nums);
+        // Compute the value range (based on the min/max values in the
+        // field) and the length range (based on the min/max length that
+        // the user has set for this barplot layer)
+        var valRange = valMax - valMin;
+        var lengthRange = maxLength - minLength;
+        if (lengthRange < 0) {
+            throw new Error(
+                "Error with scaling lengths in barplot layer " +
+                    layerNum +
+                    ": Maximum length is greater than minimum length."
+            );
+        }
+        _.each(split.numeric, function (n) {
+            // uses linear interpolation (we could add fancier
+            // scaling methods in the future as options if desired)
+            //
+            // TODO: verify that this handles negative values properly
+            // and/or support drawing negative values in the opposite
+            // direction as positive ones
+            //
+            // NOTE: we purposefully use the original feature metadata value
+            // (i.e. n) as the key in fm2length, not parseFloat(n). This is
+            // because parseFloat(n) can have a different string representation
+            // than n, so using parseFloat(n) as a key would make these lengths
+            // unretrievable without calling parseFloat() multiple times. (An
+            // example of this is the metadata value "0.0", which parseFloat()
+            // converts to 0.)
+            fm2length[n] =
+                ((parseFloat(n) - valMin) / valRange) * lengthRange + minLength;
+        });
+        return fm2length;
+    }
+
     return {
         keepUniqueKeys: keepUniqueKeys,
         naturalSort: naturalSort,
@@ -197,5 +283,6 @@ define(["underscore"], function (_) {
         isValidNumber: isValidNumber,
         parseAndValidateNum: parseAndValidateNum,
         toastMsg: toastMsg,
+        assignBarplotLengths: assignBarplotLengths,
     };
 });

--- a/empress/support_files/js/util.js
+++ b/empress/support_files/js/util.js
@@ -259,10 +259,6 @@ define(["underscore"], function (_) {
             // uses linear interpolation (we could add fancier
             // scaling methods in the future as options if desired)
             //
-            // TODO: verify that this handles negative values properly
-            // and/or support drawing negative values in the opposite
-            // direction as positive ones
-            //
             // NOTE: we purposefully use the original feature metadata value
             // (i.e. n) as the key in fm2length, not parseFloat(n). This is
             // because parseFloat(n) can have a different string representation

--- a/tests/test-util.js
+++ b/tests/test-util.js
@@ -1,4 +1,4 @@
-require(["jquery", "util"], function ($, util) {
+require(["jquery", "underscore", "util"], function ($, _, util) {
     $(document).ready(function () {
         module("Utilities");
         /**
@@ -304,6 +304,57 @@ require(["jquery", "util"], function ($, util) {
             var n = util.parseAndValidateNum(tni, 1);
             deepEqual(n, 1);
             deepEqual(tni.value, "1");
+        });
+        test("Test assignBarplotLengths", function () {
+            var fm2length = util.assignBarplotLengths(
+                ["1", "2", "3", "4"],
+                0,
+                1,
+                100,
+                "testField"
+            );
+            deepEqual(_.keys(fm2length).length, 4);
+            deepEqual(fm2length["1"], 0);
+            deepEqual(fm2length["2"], 1 / 3);
+            deepEqual(fm2length["3"], 2 / 3);
+            deepEqual(fm2length["4"], 1);
+        });
+        test("Test assignBarplotLengths (negative values)", function () {
+            var fm2length = util.assignBarplotLengths(
+                ["-1", "-2", "-3", "-4"],
+                0,
+                1,
+                100,
+                "testField"
+            );
+            deepEqual(_.keys(fm2length).length, 4);
+            deepEqual(fm2length["-4"], 0);
+            deepEqual(fm2length["-3"], 1 / 3);
+            deepEqual(fm2length["-2"], 2 / 3);
+            deepEqual(fm2length["-1"], 1);
+            // Check that mixed negative / positive values are handled normally
+            var o = util.assignBarplotLengths(["1", "0", "-1"], 1, 5, 1, "t");
+            deepEqual(_.keys(o).length, 3);
+            deepEqual(o["-1"], 1);
+            deepEqual(o["0"], 3);
+            deepEqual(o["1"], 5);
+        });
+        test("Test assignBarplotLengths (non-numeric field error)", function () {
+            throws(function () {
+                util.assignBarplotLengths(["1"], 0, 1, 100, "testField");
+            }, /Error with scaling lengths in barplot layer 100: the feature metadata field "testField" has less than 2 unique numeric values./);
+            throws(function () {
+                util.assignBarplotLengths(
+                    ["abc", "def", "ghi"],
+                    0,
+                    1,
+                    3,
+                    "fie fi fo fum"
+                );
+            }, /Error with scaling lengths in barplot layer 3: the feature metadata field "fie fi fo fum" has less than 2 unique numeric values./);
+            throws(function () {
+                util.assignBarplotLengths([], 0, 1, 1, "asdf");
+            }, /Error with scaling lengths in barplot layer 1: the feature metadata field "asdf" has less than 2 unique numeric values./);
         });
     });
 });

--- a/tests/test-util.js
+++ b/tests/test-util.js
@@ -355,6 +355,22 @@ require(["jquery", "underscore", "util"], function ($, _, util) {
             throws(function () {
                 util.assignBarplotLengths([], 0, 1, 1, "asdf");
             }, /Error with scaling lengths in barplot layer 1: the feature metadata field "asdf" has less than 2 unique numeric values./);
+            // Check that if both this error AND the max < min error are
+            // triggered, that this error has precedence. As with various other
+            // places in the code, the actual precedence doesn't matter too
+            // much; the main thing we're verifying here is that both errors
+            // happening don't somehow "cancel out". Because ... that'd be bad.
+            throws(function () {
+                util.assignBarplotLengths(["1"], 1, 0, 100, "funkyField");
+            }, /Error with scaling lengths in barplot layer 100: the feature metadata field "funkyField" has less than 2 unique numeric values./);
         });
-    });
+        test("Test assignBarplotLengths (max len < min len error)", function () {
+            throws(function () {
+                util.assignBarplotLengths(["1", "2"], 1, 0, 5, "field");
+            }, /Error with scaling lengths in barplot layer 5: Maximum length is greater than minimum length./);
+            throws(function () {
+                util.assignBarplotLengths(["1", "2"], 10, 9.9999, 6, "field");
+            }, /Error with scaling lengths in barplot layer 6: Maximum length is greater than minimum length./);
+        });
+   });
 });

--- a/tests/test-util.js
+++ b/tests/test-util.js
@@ -372,5 +372,5 @@ require(["jquery", "underscore", "util"], function ($, _, util) {
                 util.assignBarplotLengths(["1", "2"], 10, 9.9999, 6, "field");
             }, /Error with scaling lengths in barplot layer 6: Maximum length is greater than minimum length./);
         });
-   });
+    });
 });


### PR DESCRIPTION
The bug in question occurs when any of the values in the feature metadata field used for length scaling are integer values represented as floats (e.g. `"0.0"`). The mapping between unique numeric feature metadata values and their corresponding lengths is contained in a mapping where, previously, the keys were passed through  `parseFloat()` first. The problem with this is that `parseFloat("0.0")` is `0`, and keys in Objects are treated as Strings -- so the entry for `0` was inaccessible to the nodes with a feature metadata value of `0.0`, bizarrely. (The code [assumes that a value being missing as a key from that mapping means that the value in question was non-numeric](https://github.com/biocore/empress/blob/3d22b50d116fb4317060f2d65f45e91a0cb59029/empress/support_files/js/empress.js#L1360-L1366)... but in this case it was because the Object was created incorrectly.)

Anyway, now the code stores the original string values as the keys in the Object, not the `parseFloat()`-ed values. (This is the same way the color-scaling code works -- the reason that that code doesn't suffer from this bug is likely because I was able to adapt it directly from Emperor, while the length-scaling code required some extra tweaking :) The problematic code in question has also been abstracted to a new utility function, which is now decently tested.

(This bug came up when testing visualizing feature importance scores as barplots -- the majority of importance scores in the `moving-pictures-classifier/feature_importance.qza` file in [this tutorial](https://docs.qiime2.org/2020.6/tutorials/sample-classifier/) are 0s, so I noticed that a lot of these were just missing from the barplot.)