### PR TITLE
Draw barplots in the circular layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The plot is now updated so each branch is now colored by its Phylum level classi
 
 ### Exploring a feature’s closest common ancestors  
 
-So far, we’ve looked at our data using the default unrooted tree view. To visually locate these features’ closest common ancestors, it may be easier to switch to a different layout. From the main menu, click *Layout* then select *Circular* (or *Rectangular*). Our plot automatically switches to a rooted circular cladogram.   
+So far, we’ve looked at our data using the default unrooted tree view. To visually locate these features’ closest common ancestors, it may be easier to switch to a different layout. From the main menu, click *Layout* then select *Circular* (or *Rectangular*). Our plot automatically switches to a rooted layout.
 
 Now zoom into the longest branch of the top cluster and click on the closest external node that has a different Phylum classification (light blue).   
 
@@ -143,7 +143,9 @@ In this plot the colored branches represent lineages that are unique to the corr
 
 Similarly to other tree visualization tools like [iTOL](https://itol.embl.de/), Empress can draw barplots in order to annotate tips of the tree with various types of information. Barplots are useful for doing this (moreso than node coloring, sometimes) because multiple "layers" of barplots can be shown at the same time -- this allows for us to view multiple types of data for the same tip simultaneously. Check out Figure 1 of [Song and Sanders et al. 2020](https://mbio.asm.org/node/61763.full) for just one example of a tree visualization using multiple layers of barplots for a pretty and effective figure.
 
-Barplots in Empress are currently only compatible with the rectangular layout, but support for circular-layout barplots is planned. To use barplots, change the layout to *Rectangular* (using the *Layout* section of the main menu), and then open up the *Barplots* section of the main menu and check the `Draw Barplots?` checkbox. By default, a red bar of uniform length will be drawn for every tip in the tree:
+Barplots in Empress are compatible with either the rectangular or circular layouts. Here we'll use the rectangular layout, but feel free to follow along with the circular layout if you prefer!
+
+First off, change the layout to *Rectangular* (using the *Layout* section of the main menu), and then open up the *Barplots* section of the main menu and check the `Draw Barplots?` checkbox. By default, a red bar of uniform length will be drawn for every tip in the tree:
 
 ![empress barplots initial view](docs/moving-pictures/img/empress_barplots_1.png)
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Similarly to other tree visualization tools like [iTOL](https://itol.embl.de/), 
 
 Barplots in Empress are compatible with either the rectangular or circular layouts. Here we'll use the rectangular layout, but feel free to follow along with the circular layout if you prefer!
 
-First off, change the layout to *Rectangular* (using the *Layout* section of the main menu), and then open up the *Barplots* section of the main menu and check the `Draw Barplots?` checkbox. By default, a red bar of uniform length will be drawn for every tip in the tree:
+First off, change the layout to *Rectangular* (using the *Layout* section of the main menu), and then open up the *Barplots* section of the main menu and check the `Draw Barplots?` checkbox. Click the *Update* button that appears. By default, a red bar of uniform length will be drawn for every tip in the tree:
 
 ![empress barplots initial view](docs/moving-pictures/img/empress_barplots_1.png)
 

--- a/empress/support_files/js/barplot-panel-handler.js
+++ b/empress/support_files/js/barplot-panel-handler.js
@@ -191,7 +191,7 @@ define(["underscore", "BarplotLayer", "Colorer"], function (
     /**
      * Array containing the names of layouts compatible with barplots.
      */
-    BarplotPanel.SUPPORTED_LAYOUTS = ["Rectangular"];
+    BarplotPanel.SUPPORTED_LAYOUTS = ["Rectangular", "Circular"];
 
     return BarplotPanel;
 });

--- a/empress/support_files/js/barplot-panel-handler.js
+++ b/empress/support_files/js/barplot-panel-handler.js
@@ -74,7 +74,9 @@ define(["underscore", "BarplotLayer", "Colorer"], function (
                 scope.addOptions.classList.remove("hidden");
                 scope.updateButton.classList.remove("hidden");
                 scope.enabled = true;
-                scope.empress.drawBarplots(scope.layers);
+                // We don't immediately draw barplots: see
+                // https://github.com/biocore/empress/issues/343. The user has
+                // to click "Update" first.
             } else {
                 scope.layerContainer.classList.add("hidden");
                 scope.addOptions.classList.add("hidden");

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -1316,13 +1316,13 @@ define([
             // than computing this for every section in the stacked barplot --
             // doable b/c this information is constant through the sections.
             var y, ty, by;
-            var nodeAngleInfo;
+            var angleInfo;
             if (scope._currentLayout === "Rectangular") {
                 y = scope.getY(node);
                 ty = y + halfyrscf;
                 by = y - halfyrscf;
             } else if (scope._currentLayout === "Circular") {
-                nodeAngleInfo = scope._getNodeAngleInfo(node, halfAngleRange);
+                angleInfo = scope._getNodeAngleInfo(node, halfAngleRange);
             }
 
             // For each unique value for this sample metadata field...
@@ -1368,7 +1368,7 @@ define([
                             coords,
                             prevSectionMaxD,
                             thisSectionMaxD,
-                            nodeAngleInfo,
+                            angleInfo,
                             sectionColor
                         );
                     } else {

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -865,10 +865,10 @@ define([
      *     /  \      /
      * tL1/    \    /
      *    \     \  *
-     *     \     \bR-----tR2
+     *     \     \bR-----tR2        (Inner radius)
      *      \    /         |
      *       \  /          |
-     *        bL---------tL2
+     *        bL---------tL2        (Outer radius)
      *
      * Here, tL1 and tR2 are on the "lower angle" and tL2 and tR2 are on the
      * "upper angle," as specified in the angleInfo parameter.
@@ -878,8 +878,8 @@ define([
      *
      * @param {Array} coords Array containing coordinate + color data, to be
      *                       passed to Drawer.loadBarplotBuff().
-     * @param {Number} r Inner radius of the bar to draw
-     * @param {Number} outR Outer radius of the bar to draw
+     * @param {Number} r1 Inner radius of the bar to draw
+     * @param {Number} r2 Outer radius of the bar to draw
      * @param {Object} angleInfo Object returned by this._getNodeAngleInfo()
      *                           for the node this bar is being drawn for.
      * @param {Array} color The GL color to draw / fill both triangles with.
@@ -887,8 +887,8 @@ define([
      */
     Empress.prototype._addCircularBarCoords = function (
         coords,
-        r,
-        outR,
+        r1,
+        r2,
         angleInfo,
         color
     ) {
@@ -901,23 +901,23 @@ define([
         // these coordinates (and therefore the Polar coordinates).
         // For more detail on this, see for example
         // https://tutorial.math.lamar.edu/classes/calcii/polarcoordinates.aspx
-        var centerBL = [outR * angleInfo.angleCos, outR * angleInfo.angleSin];
-        var centerBR = [r * angleInfo.angleCos, r * angleInfo.angleSin];
+        var centerBL = [r2 * angleInfo.angleCos, r2 * angleInfo.angleSin];
+        var centerBR = [r1 * angleInfo.angleCos, r1 * angleInfo.angleSin];
         var t1 = {
             tL: [
-                outR * angleInfo.lowerAngleCos,
-                outR * angleInfo.lowerAngleSin,
+                r2 * angleInfo.lowerAngleCos,
+                r2 * angleInfo.lowerAngleSin,
             ],
-            tR: [r * angleInfo.lowerAngleCos, r * angleInfo.lowerAngleSin],
+            tR: [r1 * angleInfo.lowerAngleCos, r1 * angleInfo.lowerAngleSin],
             bL: centerBL,
             bR: centerBR,
         };
         var t2 = {
             tL: [
-                outR * angleInfo.upperAngleCos,
-                outR * angleInfo.upperAngleSin,
+                r2 * angleInfo.upperAngleCos,
+                r2 * angleInfo.upperAngleSin,
             ],
-            tR: [r * angleInfo.upperAngleCos, r * angleInfo.upperAngleSin],
+            tR: [r1 * angleInfo.upperAngleCos, r1 * angleInfo.upperAngleSin],
             bL: centerBL,
             bR: centerBR,
         };

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -311,7 +311,7 @@ define([
     };
 
     /**
-     * Retrive an attribute from a node.
+     * Retrieve an attribute from a node.
      *
      * @param{Array} node An array that holds all the attributes for a given
      *                     node. Note: this is an entry in this._treeData.
@@ -614,7 +614,7 @@ define([
     };
 
     /**
-     * Retrives the node coordinate info
+     * Retrieves the node coordinate info
      * format of node coordinate info: [x, y, red, green, blue, ...]
      *
      * @return {Array}

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -1087,6 +1087,10 @@ define([
                         maxX = x;
                     }
                 } else if (this._currentLayout === "Circular") {
+                    // Since x-coordinates are equal to r*cos(theta), we can
+                    // divide a given node's x-coordinate by cos(theta) to get
+                    // its radius. (There is probably a more efficient way to
+                    // do this.)
                     var r =
                         this.getX(this._treeData[i]) /
                         Math.cos(this.getNodeInfo(this._treeData[i], "angle"));
@@ -1151,8 +1155,15 @@ define([
         // Do most of the hard work: compute the frequencies for each tip (only
         // the tips present in the BIOM table, that is)
         var feature2freqs = this._biom.getFrequencyMap(layer.colorBySMField);
-        // Bar thickness
+
+        // Bar thickness (rect layout barplots)
         var halfyrscf = this._yrscf / 2;
+
+        // Bar thickness (circular layout barplots)
+        // This is really (2pi / # leaves) / 2, but the 2s cancel
+        // out so it's just pi / # leaves
+        var halfAngleRange = Math.PI / scope._tree.numleaves();
+
         // For each tip in the BIOM table...
         // (We implicitly ignore [and don't draw anything for] tips that
         // *aren't* in the BIOM table.)
@@ -1211,14 +1222,12 @@ define([
                         scope._addTriangleCoords(coords, corners, sectionColor);
                     } else if (scope._currentLayout === "Circular") {
                         var angle = scope.getNodeInfo(node, "angle");
-                        // This is really (2pi / # leaves) / 2, but the 2s cancel
-                        // out so it's just pi / # leaves
-                        // TODO: only compute these once per node
-                        var halfAngleRange = Math.PI / scope._tree.numleaves();
-                        var lowerAngleCos = Math.cos(angle - halfAngleRange);
-                        var upperAngleCos = Math.cos(angle + halfAngleRange);
-                        var lowerAngleSin = Math.sin(angle - halfAngleRange);
-                        var upperAngleSin = Math.sin(angle + halfAngleRange);
+                        var lowerAngle = angle - halfAngleRange;
+                        var upperAngle = angle + halfAngleRange;
+                        var lowerAngleCos = Math.cos(lowerAngle);
+                        var upperAngleCos = Math.cos(upperAngle);
+                        var lowerAngleSin = Math.sin(lowerAngle);
+                        var upperAngleSin = Math.sin(upperAngle);
                         var angleCos = Math.cos(angle);
                         var angleSin = Math.sin(angle);
                         var r = prevSectionMaxX;
@@ -1232,21 +1241,21 @@ define([
                         //  x = radius * cos(theta)
                         //  y = radius * sin(theta)
                         // See e.g. https://tutorial.math.lamar.edu/classes/calcii/polarcoordinates.aspx.
-                        // So every coordinate in one of these arrays is just
+                        // So every position defined by these arrays is just
                         // being converted from Polar to Cartesian.
-                        // TODO: don't compute redundant stuff (e.g. the bL and
-                        // bRs) more than once
+                        var centerBL = [outR * angleCos, outR * angleSin];
+                        var centerBR = [r * angleCos, r * angleSin];
                         var t1 = {
                             tL: [outR * lowerAngleCos, outR * lowerAngleSin],
                             tR: [r * lowerAngleCos, r * lowerAngleSin],
-                            bL: [outR * angleCos, outR * angleSin],
-                            bR: [r * angleCos, r * angleSin],
+                            bL: centerBL,
+                            bR: centerBR,
                         };
                         var t2 = {
                             tL: [outR * upperAngleCos, outR * upperAngleSin],
                             tR: [r * upperAngleCos, r * upperAngleSin],
-                            bL: [outR * angleCos, outR * angleSin],
-                            bR: [r * angleCos, r * angleSin],
+                            bL: centerBL,
+                            bR: centerBR,
                         };
                         scope._addTriangleCoords(coords, t1, sectionColor);
                         scope._addTriangleCoords(coords, t2, sectionColor);
@@ -1350,6 +1359,7 @@ define([
         // Now that we know how to encode each tip's bar, we can finally go
         // iterate through the tree and create bars for the tips.
         var halfyrscf = this._yrscf / 2;
+        var halfAngleRange = Math.PI / this._tree.numleaves();
         for (i = 1; i < this._tree.size; i++) {
             if (this._tree.isleaf(this._tree.postorderselect(i))) {
                 var node = this._treeData[i];
@@ -1418,18 +1428,12 @@ define([
                     this._addTriangleCoords(coords, corners, color);
                 } else if (this._currentLayout === "Circular") {
                     var angle = this.getNodeInfo(node, "angle");
-                    // This is really (2pi / # leaves) / 2, but the 2s cancel
-                    // out so it's just pi / # leaves
-                    // TODO: don't compute this for every tip, just move it
-                    // above
-                    var halfAngleRange = Math.PI / this._tree.numleaves();
-                    // TODO: store this in the layout data when it's computed
-                    // via JS...? So we don't have to figure it out for every
-                    // node
-                    var lowerAngleCos = Math.cos(angle - halfAngleRange);
-                    var upperAngleCos = Math.cos(angle + halfAngleRange);
-                    var lowerAngleSin = Math.sin(angle - halfAngleRange);
-                    var upperAngleSin = Math.sin(angle + halfAngleRange);
+                    var lowerAngle = angle - halfAngleRange;
+                    var upperAngle = angle + halfAngleRange;
+                    var lowerAngleCos = Math.cos(lowerAngle);
+                    var upperAngleCos = Math.cos(upperAngle);
+                    var lowerAngleSin = Math.sin(lowerAngle);
+                    var upperAngleSin = Math.sin(upperAngle);
                     var angleCos = Math.cos(angle);
                     var angleSin = Math.sin(angle);
                     var r = prevLayerMaxX;
@@ -1437,19 +1441,19 @@ define([
                     // Draws two rectangles. Will look jagged for small trees,
                     // but should look smooth enough for trees with enough
                     // tips.
-                    // TODO: don't compute redundant stuff (e.g. the bL and
-                    // bRs) more than once
+                    var centerBL = [outR * angleCos, outR * angleSin];
+                    var centerBR = [r * angleCos, r * angleSin];
                     var t1 = {
                         tL: [outR * lowerAngleCos, outR * lowerAngleSin],
                         tR: [r * lowerAngleCos, r * lowerAngleSin],
-                        bL: [outR * angleCos, outR * angleSin],
-                        bR: [r * angleCos, r * angleSin],
+                        bL: centerBL,
+                        bR: centerBR,
                     };
                     var t2 = {
                         tL: [outR * upperAngleCos, outR * upperAngleSin],
                         tR: [r * upperAngleCos, r * upperAngleSin],
-                        bL: [outR * angleCos, outR * angleSin],
-                        bR: [r * angleCos, r * angleSin],
+                        bL: centerBL,
+                        bR: centerBR,
                     };
                     this._addTriangleCoords(coords, t1, color);
                     this._addTriangleCoords(coords, t2, color);

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -1222,11 +1222,9 @@ define([
                         var angleSin = Math.sin(angle);
                         var r = prevSectionMaxX;
                         var outR = thisSectionMaxX;
-                        // Currently, this draws just a single rectangle. For trees
-                        // with a large enough amount of tips this is fine, but for
-                        // trees with just a few tips this'll look funky and we'll
-                        // need to approximate this by drawing multiple rectangles
-                        // along the arc between the lower and upper angle.
+                        // Draws two rectangles. Will look jagged for small trees,
+                        // but should look smooth enough for trees with enough
+                        // tips.
                         var t1 = {
                             tL: [outR * lowerAngleCos, outR * lowerAngleSin],
                             tR: [r * lowerAngleCos, r * lowerAngleSin],
@@ -1423,11 +1421,9 @@ define([
                     var angleSin = Math.sin(angle);
                     var r = prevLayerMaxX;
                     var outR = prevLayerMaxX + length;
-                    // Currently, this draws just a single rectangle. For trees
-                    // with a large enough amount of tips this is fine, but for
-                    // trees with just a few tips this'll look funky and we'll
-                    // need to approximate this by drawing multiple rectangles
-                    // along the arc between the lower and upper angle.
+                    // Draws two rectangles. Will look jagged for small trees,
+                    // but should look smooth enough for trees with enough
+                    // tips.
                     var t1 = {
                         tL: [outR * lowerAngleCos, outR * lowerAngleSin],
                         tR: [r * lowerAngleCos, r * lowerAngleSin],

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -1179,6 +1179,32 @@ define([
             // through the unique values in this sample metadata field below.
             var prevSectionMaxX = prevLayerMaxX;
 
+            var y, ty, by;
+            var angle,
+                lowerAngle,
+                upperAngle,
+                angleCos,
+                angleSin,
+                lowerAngleCos,
+                lowerAngleSin,
+                upperAngleCos,
+                upperAngleSin;
+            if (scope._currentLayout === "Rectangular") {
+                y = scope.getY(node);
+                ty = y + halfyrscf;
+                by = y - halfyrscf;
+            } else if (scope._currentLayout === "Circular") {
+                angle = scope.getNodeInfo(node, "angle");
+                lowerAngle = angle - halfAngleRange;
+                upperAngle = angle + halfAngleRange;
+                angleCos = Math.cos(angle);
+                angleSin = Math.sin(angle);
+                lowerAngleCos = Math.cos(lowerAngle);
+                upperAngleCos = Math.cos(upperAngle);
+                lowerAngleSin = Math.sin(lowerAngle);
+                upperAngleSin = Math.sin(upperAngle);
+            }
+
             // For each unique value for this sample metadata field...
             // NOTE: currently we iterate through all of sortedUniqueValues
             // once for every tip in the table, detecting and skipping
@@ -1210,9 +1236,6 @@ define([
                     // presence information for this tip.
                     var thisSectionMaxX = prevSectionMaxX + barSectionLen;
                     if (scope._currentLayout === "Rectangular") {
-                        var y = scope.getY(node);
-                        var ty = y + halfyrscf;
-                        var by = y - halfyrscf;
                         var corners = {
                             tL: [prevSectionMaxX, ty],
                             tR: [thisSectionMaxX, ty],
@@ -1221,15 +1244,6 @@ define([
                         };
                         scope._addTriangleCoords(coords, corners, sectionColor);
                     } else if (scope._currentLayout === "Circular") {
-                        var angle = scope.getNodeInfo(node, "angle");
-                        var lowerAngle = angle - halfAngleRange;
-                        var upperAngle = angle + halfAngleRange;
-                        var lowerAngleCos = Math.cos(lowerAngle);
-                        var upperAngleCos = Math.cos(upperAngle);
-                        var lowerAngleSin = Math.sin(lowerAngle);
-                        var upperAngleSin = Math.sin(upperAngle);
-                        var angleCos = Math.cos(angle);
-                        var angleSin = Math.sin(angle);
                         var r = prevSectionMaxX;
                         var outR = thisSectionMaxX;
                         // Draws two rectangles. Will look jagged for small trees,

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -1225,6 +1225,14 @@ define([
                         // Draws two rectangles. Will look jagged for small trees,
                         // but should look smooth enough for trees with enough
                         // tips.
+                        // This works because Polar coordinates (of the form
+                        // (radius, theta)) can be converted to Cartesian
+                        // coordinates (x, y) by using the formulae:
+                        //  x = radius * cos(theta)
+                        //  y = radius * sin(theta)
+                        // See e.g. https://tutorial.math.lamar.edu/classes/calcii/polarcoordinates.aspx.
+                        // So every coordinate in one of these arrays is just
+                        // being converted from Polar to Cartesian.
                         var t1 = {
                             tL: [outR * lowerAngleCos, outR * lowerAngleSin],
                             tR: [r * lowerAngleCos, r * lowerAngleSin],

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -904,19 +904,13 @@ define([
         var centerBL = [r2 * angleInfo.angleCos, r2 * angleInfo.angleSin];
         var centerBR = [r1 * angleInfo.angleCos, r1 * angleInfo.angleSin];
         var t1 = {
-            tL: [
-                r2 * angleInfo.lowerAngleCos,
-                r2 * angleInfo.lowerAngleSin,
-            ],
+            tL: [r2 * angleInfo.lowerAngleCos, r2 * angleInfo.lowerAngleSin],
             tR: [r1 * angleInfo.lowerAngleCos, r1 * angleInfo.lowerAngleSin],
             bL: centerBL,
             bR: centerBR,
         };
         var t2 = {
-            tL: [
-                r2 * angleInfo.upperAngleCos,
-                r2 * angleInfo.upperAngleSin,
-            ],
+            tL: [r2 * angleInfo.upperAngleCos, r2 * angleInfo.upperAngleSin],
             tR: [r1 * angleInfo.upperAngleCos, r1 * angleInfo.upperAngleSin],
             bL: centerBL,
             bR: centerBR,

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -888,8 +888,8 @@ define([
      *
      * @param {Array} coords Array containing coordinate + color data, to be
      *                       passed to Drawer.loadBarplotBuff().
-     * @param {Number} r1 Inner radius of the bar to draw
-     * @param {Number} r2 Outer radius of the bar to draw
+     * @param {Number} r1 Inner radius of the bar to draw.
+     * @param {Number} r2 Outer radius of the bar to draw.
      * @param {Object} angleInfo Object returned by this._getNodeAngleInfo()
      *                           for the node this bar is being drawn for.
      * @param {Array} color The GL color to draw / fill both triangles with.

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -1241,7 +1241,7 @@ define([
                     // preorder traversal through the tree to see which tip has
                     // the largest cumulative length, then scale that to the
                     // radius value in the layout? Not sure if this step is a
-                    // bottleneck, though.)
+                    // bottleneck worth spending time working on, though.)
                     var r =
                         this.getX(this._treeData[i]) /
                         Math.cos(this.getNodeInfo(this._treeData[i], "angle"));

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -1215,10 +1215,12 @@ define([
         var coords = [];
         // The "D" stands for displacement. For the rectangular layout, this
         // variable represents the rightmost node's x-coordinate; for the
-        // circular layout, this variable represents the node with the largest
-        // radius' radius. (This is used when determining how "close" to the
-        // root node we can start drawing barplots and not cross over any
-        // nodes.)
+        // circular layout, this variable represents the node farthest away
+        // from the root's distance from the root (a.k.a. radius, since the
+        // root is (0, 0)).
+        // In any case, the maxD value is used when determining how "close"
+        // to the root node we can start drawing barplots without crossing over
+        // any nodes.
         var maxD = -Infinity;
         for (var i = 1; i < this._tree.size; i++) {
             if (this._tree.isleaf(this._tree.postorderselect(i))) {
@@ -1228,10 +1230,18 @@ define([
                         maxD = x;
                     }
                 } else if (this._currentLayout === "Circular") {
+                    // We don't currently store nodes' radii, so we figure this
+                    // out by looking at the node's x-coordinate and angle.
                     // Since x-coordinates are equal to r*cos(theta), we can
                     // divide a given node's x-coordinate by cos(theta) to get
-                    // its radius. (There is probably a more efficient way to
-                    // do this.)
+                    // its radius. I know we can get the same result by
+                    // computing sqrt(x^2 + y^2) (a.k.a. distance from the
+                    // root at (0, 0)), but this seems faster. (There is still
+                    // probably an even faster way to do this though; maybe a
+                    // preorder traversal through the tree to see which tip has
+                    // the largest cumulative length, then scale that to the
+                    // radius value in the layout? Not sure if this step is a
+                    // bottleneck, though.)
                     var r =
                         this.getX(this._treeData[i]) /
                         Math.cos(this.getNodeInfo(this._treeData[i], "angle"));

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -1213,6 +1213,7 @@ define([
                         var angle = scope.getNodeInfo(node, "angle");
                         // This is really (2pi / # leaves) / 2, but the 2s cancel
                         // out so it's just pi / # leaves
+                        // TODO: only compute these once per node
                         var halfAngleRange = Math.PI / scope._tree.numleaves();
                         var lowerAngleCos = Math.cos(angle - halfAngleRange);
                         var upperAngleCos = Math.cos(angle + halfAngleRange);
@@ -1233,6 +1234,8 @@ define([
                         // See e.g. https://tutorial.math.lamar.edu/classes/calcii/polarcoordinates.aspx.
                         // So every coordinate in one of these arrays is just
                         // being converted from Polar to Cartesian.
+                        // TODO: don't compute redundant stuff (e.g. the bL and
+                        // bRs) more than once
                         var t1 = {
                             tL: [outR * lowerAngleCos, outR * lowerAngleSin],
                             tR: [r * lowerAngleCos, r * lowerAngleSin],
@@ -1417,6 +1420,8 @@ define([
                     var angle = this.getNodeInfo(node, "angle");
                     // This is really (2pi / # leaves) / 2, but the 2s cancel
                     // out so it's just pi / # leaves
+                    // TODO: don't compute this for every tip, just move it
+                    // above
                     var halfAngleRange = Math.PI / this._tree.numleaves();
                     // TODO: store this in the layout data when it's computed
                     // via JS...? So we don't have to figure it out for every
@@ -1432,6 +1437,8 @@ define([
                     // Draws two rectangles. Will look jagged for small trees,
                     // but should look smooth enough for trees with enough
                     // tips.
+                    // TODO: don't compute redundant stuff (e.g. the bL and
+                    // bRs) more than once
                     var t1 = {
                         tL: [outR * lowerAngleCos, outR * lowerAngleSin],
                         tR: [r * lowerAngleCos, r * lowerAngleSin],

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -796,9 +796,6 @@ define([
      * Returns an Object describing circular layout angle information for a
      * node.
      *
-     * (TODO: throw an error if the current layout isn't circular, in which
-     * case angle information won't be available in the first place)
-     *
      * @param {Array} node An array that holds all the attributes for a given
      *                    node. As with the "node" parameter of
      *                    this.getNodeInfo(), this is an entry in the tree
@@ -825,28 +822,41 @@ define([
      *                            This Object can be passed directly into
      *                            this._addCircularBarCoords() as its angleInfo
      *                            parameter.
+     *
+     * @throws {Error} If the current layout is not "Circular".
      */
     Empress.prototype._getNodeAngleInfo = function (node, halfAngleRange) {
-        var angle = this.getNodeInfo(node, "angle");
-        var lowerAngle = angle - halfAngleRange;
-        var upperAngle = angle + halfAngleRange;
-        var angleCos = Math.cos(angle);
-        var angleSin = Math.sin(angle);
-        var lowerAngleCos = Math.cos(lowerAngle);
-        var lowerAngleSin = Math.sin(lowerAngle);
-        var upperAngleCos = Math.cos(upperAngle);
-        var upperAngleSin = Math.sin(upperAngle);
-        return {
-            angle: angle,
-            lowerAngle: lowerAngle,
-            upperAngle: upperAngle,
-            angleCos: angleCos,
-            angleSin: angleSin,
-            lowerAngleCos: lowerAngleCos,
-            lowerAngleSin: lowerAngleSin,
-            upperAngleCos: upperAngleCos,
-            upperAngleSin: upperAngleSin,
-        };
+        if (this._currentLayout === "Circular") {
+            var angle = this.getNodeInfo(node, "angle");
+            var lowerAngle = angle - halfAngleRange;
+            var upperAngle = angle + halfAngleRange;
+            var angleCos = Math.cos(angle);
+            var angleSin = Math.sin(angle);
+            var lowerAngleCos = Math.cos(lowerAngle);
+            var lowerAngleSin = Math.sin(lowerAngle);
+            var upperAngleCos = Math.cos(upperAngle);
+            var upperAngleSin = Math.sin(upperAngle);
+            return {
+                angle: angle,
+                lowerAngle: lowerAngle,
+                upperAngle: upperAngle,
+                angleCos: angleCos,
+                angleSin: angleSin,
+                lowerAngleCos: lowerAngleCos,
+                lowerAngleSin: lowerAngleSin,
+                upperAngleCos: upperAngleCos,
+                upperAngleSin: upperAngleSin,
+            };
+        } else {
+            // When layouts are ported to JS in the future, catching this error
+            // will be more important -- since then the node's angle
+            // attribute won't even be accessible, and this function would
+            // likely just fail silently otherwise (returning an Object with a
+            // bunch of undefined / NaN values)
+            throw new Error(
+                "_getNodeAngleInfo() called when not in circular layout"
+            );
+        }
     };
 
     /**

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -1308,13 +1308,22 @@ define([
         // the tips present in the BIOM table, that is)
         var feature2freqs = this._biom.getFrequencyMap(layer.colorBySMField);
 
-        // Bar thickness (rect layout barplots)
-        var halfyrscf = this._yrscf / 2;
-
-        // Bar thickness (circular layout barplots)
-        // This is really (2pi / # leaves) / 2, but the 2s cancel
-        // out so it's just pi / # leaves
-        var halfAngleRange = Math.PI / scope._tree.numleaves();
+        // Only bother computing the halfyrscf / halfAngleRange value we need.
+        // (this._tree.numleaves() does iterate over the full tree, at least
+        // as of writing, so avoiding calling it if possible is a good idea.)
+        // NOTE: This code is duplicated between this function and
+        // addFMBarplotLayerCoords(). Not sure if it's worth the work to
+        // abstract it, though, since it boils down to ~6 lines.
+        var halfyrscf, halfAngleRange;
+        if (this._currentLayout === "Rectangular") {
+            // Bar thickness (rect layout barplots)
+            halfyrscf = this._yrscf / 2;
+        } else {
+            // Bar thickness (circular layout barplots)
+            // This is really (2pi / # leaves) / 2, but the 2s cancel
+            // out so it's just pi / # leaves
+            halfAngleRange = Math.PI / this._tree.numleaves();
+        }
 
         // For each tip in the BIOM table...
         // (We implicitly ignore [and don't draw anything for] tips that
@@ -1494,8 +1503,12 @@ define([
 
         // Now that we know how to encode each tip's bar, we can finally go
         // iterate through the tree and create bars for the tips.
-        var halfyrscf = this._yrscf / 2;
-        var halfAngleRange = Math.PI / this._tree.numleaves();
+        var halfyrscf, halfAngleRange;
+        if (this._currentLayout === "Rectangular") {
+            halfyrscf = this._yrscf / 2;
+        } else {
+            halfAngleRange = Math.PI / this._tree.numleaves();
+        }
         for (i = 1; i < this._tree.size; i++) {
             if (this._tree.isleaf(this._tree.postorderselect(i))) {
                 var node = this._treeData[i];

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -1317,6 +1317,10 @@ define([
             // through the unique values in this sample metadata field below.
             var prevSectionMaxD = prevLayerMaxD;
 
+            // Compute y-coordinate / angle information up front. Doing this
+            // here lets us compute this only once per tip (per layer), rather
+            // than computing this for every section in the stacked barplot --
+            // doable b/c this information is constant through the sections.
             var y, ty, by;
             var nodeAngleInfo;
             if (scope._currentLayout === "Rectangular") {

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -1331,7 +1331,13 @@ define([
                 y = scope.getY(node);
                 ty = y + halfyrscf;
                 by = y - halfyrscf;
-            } else if (scope._currentLayout === "Circular") {
+            } else {
+                // NOTE: In this function and in addFMBarplotLayerCoords(), we
+                // don't bother checking if scope._currentLayout is not
+                // Rectangular / Circular. This should already have been
+                // checked for in drawBarplots(), so we can safely assume that
+                // we're in one of the supported layouts. (If not, it's the
+                // caller's problem.)
                 angleInfo = scope._getNodeAngleInfo(node, halfAngleRange);
             }
 
@@ -1373,7 +1379,7 @@ define([
                             bR: [thisSectionMaxD, by],
                         };
                         scope._addTriangleCoords(coords, corners, sectionColor);
-                    } else if (scope._currentLayout === "Circular") {
+                    } else {
                         scope._addCircularBarCoords(
                             coords,
                             prevSectionMaxD,
@@ -1381,8 +1387,6 @@ define([
                             angleInfo,
                             sectionColor
                         );
-                    } else {
-                        throw new Error("Unsupported barplot layout");
                     }
                     prevSectionMaxD = thisSectionMaxD;
                 }
@@ -1548,20 +1552,13 @@ define([
                         bR: [prevLayerMaxD + length, by],
                     };
                     this._addTriangleCoords(coords, corners, color);
-                } else if (this._currentLayout === "Circular") {
+                } else {
                     this._addCircularBarCoords(
                         coords,
                         prevLayerMaxD,
                         prevLayerMaxD + length,
                         this._getNodeAngleInfo(node, halfAngleRange),
                         color
-                    );
-                } else {
-                    // This should never happen, since an unsupported layout
-                    // (e.g. unrooted) being selected should hide the barplot
-                    // controls and un-draw barplots.
-                    throw new Error(
-                        "Unsupported layout when drawing f.m. barplots"
                     );
                 }
             }

--- a/empress/support_files/templates/side-panel.html
+++ b/empress/support_files/templates/side-panel.html
@@ -149,8 +149,8 @@
   </div>
   <div id="barplot-unavailable-content">
     <p class="side-panel-notes" style="font-weight: bold;">
-      Barplots are currently only supported in the rectangular layout. Please
-      change the layout in order to use barplots.
+      Barplots are only supported in the rectangular and circular layouts.
+      Please change the layout in order to use barplots.
     </p>
   </div>
 </div>

--- a/tests/test-empress.js
+++ b/tests/test-empress.js
@@ -1056,5 +1056,30 @@ require(["jquery", "UtilitiesForTesting", "util", "chroma"], function (
                 );
             }, /F. metadata coloring method "i'm invalid!" unrecognized./);
         });
+        test("Test _getNodeAngleInfo", function () {
+            var scope = this;
+            this.empress.updateLayout("Circular");
+            var node = this.empress._treeData[1];
+            // the halfAngleRange is 2pi / 4 (since there are 4 leaves in this
+            // test tree), or equivalently pi / 2.
+            var piover2 = Math.PI / 2;
+            var angleInfo = this.empress._getNodeAngleInfo(node, piover2);
+            equal(angleInfo.angle, 0);
+            equal(angleInfo.lowerAngle.toFixed(5), -piover2.toFixed(5));
+            equal(angleInfo.upperAngle.toFixed(5), piover2.toFixed(5));
+            equal(angleInfo.angleCos, 1);
+            equal(angleInfo.angleSin, 0);
+            equal(angleInfo.lowerAngleCos.toFixed(5), 0);
+            equal(angleInfo.lowerAngleSin.toFixed(5), -1);
+            equal(angleInfo.upperAngleCos.toFixed(5), 0);
+            equal(angleInfo.upperAngleSin.toFixed(5), 1);
+            // Test that this throws an error if the tree is not in the
+            // circular layout
+            this.empress.updateLayout("Rectangular");
+            // (Gotta escape the parens in the regex or else it breaks)
+            throws(function () {
+                scope.empress._getNodeAngleInfo(node, Math.PI / 2);
+            }, /_getNodeAngleInfo\(\) called when not in circular layout/);
+        });
     });
 });

--- a/tests/test-empress.js
+++ b/tests/test-empress.js
@@ -1171,18 +1171,22 @@ require(["jquery", "UtilitiesForTesting", "util", "chroma"], function (
                                     // bR
                                     // 100 * cos(0) = 100
                                     equal(v, 100);
+                                    break;
                                 case 4:
                                     // tR on the lower rectangle
-                                    // TODO test
+                                    // 100 * cos(-pi/2) = 0
+                                    equal(v.toFixed(5), 0);
                                     break;
                                 case 6:
                                 case 9:
                                     // tL on the upper rectangle
-                                    // TODO test
+                                    // 200 * cos(pi/2) = 0
+                                    equal(v.toFixed(5), 0);
                                     break;
                                 case 10:
                                     // tR on the upper rectangle
-                                    // TODO test
+                                    // 100 * cos(pi/2) = 0
+                                    equal(v.toFixed(5), 0);
                                     break;
                                 default:
                                     throw new Error(

--- a/tests/test-empress.js
+++ b/tests/test-empress.js
@@ -1089,9 +1089,11 @@ require(["jquery", "UtilitiesForTesting", "util", "chroma"], function (
             // The [0.25, 0.5, 0.75] is the GL color we use. (Mostly chosen
             // here so that each R/G/B value is distinct; apparently this is a
             // weird shade of blue when you draw it.)
-            this.empress._addCircularBarCoords(
-                coords, 100, 200, angleInfo, [0.25, 0.5, 0.75]
-            );
+            this.empress._addCircularBarCoords(coords, 100, 200, angleInfo, [
+                0.25,
+                0.5,
+                0.75,
+            ]);
             // Each call of _addTriangleCoords() draws a rectangle with two
             // triangles. This involves adding 6 positions to coords, and since
             // positions take up 5 spaces in an array here ([x, y, r, g, b]),
@@ -1135,7 +1137,7 @@ require(["jquery", "UtilitiesForTesting", "util", "chroma"], function (
             // (Of course when you look at the other side of the circle left
             // and right'll be switched around. We just stick to this notation
             // here to make testing this less difficult.)
-            _.each(coords, function(v, i) {
+            _.each(coords, function (v, i) {
                 if (i === 0) {
                     equal(v, "preexisting thing in the array");
                 } else {
@@ -1191,9 +1193,9 @@ require(["jquery", "UtilitiesForTesting", "util", "chroma"], function (
                                 default:
                                     throw new Error(
                                         "This should never happen: index " +
-                                        i +
-                                        " has a floor(i/5) value of " +
-                                        floor
+                                            i +
+                                            " has a floor(i/5) value of " +
+                                            floor
                                     );
                             }
                             break;

--- a/tests/test-empress.js
+++ b/tests/test-empress.js
@@ -1268,7 +1268,7 @@ require(["jquery", "UtilitiesForTesting", "util", "chroma"], function (
                         default:
                             throw new Error(
                                 "If this is encountered, something went " +
-                                "very wrong."
+                                    "very wrong."
                             );
                     }
                 }

--- a/tests/test-empress.js
+++ b/tests/test-empress.js
@@ -1274,5 +1274,86 @@ require(["jquery", "UtilitiesForTesting", "util", "chroma"], function (
                 }
             });
         });
+        test("Test _addRectangularBarCoords", function () {
+            var coords = [];
+            var lx = 0;
+            var rx = 1;
+            var by = 2;
+            var ty = 3;
+            var color = [0.3, 0.8, 0.9];
+            this.empress._addRectangularBarCoords(
+                coords,
+                lx,
+                rx,
+                by,
+                ty,
+                color
+            );
+            // Each point has 5 values (x, y, r, g, b) and there are 3
+            // triangles (6 points) added, so the length of coords should now
+            // be 6 * 5 = 30.
+            equal(coords.length, 30);
+            // We use a pared-down form of the iteration test used above in
+            // testing _addCircularBarCoords(). This function is simpler (it
+            // only calls _addTriangleCoords() once, so only one rectangle is
+            // added), and there isn't a preexisting element in coords, so
+            // checking things is much less involved.
+            _.each(coords, function (v, i) {
+                var floor = Math.floor(i / 5);
+                switch (i % 5) {
+                    case 0:
+                        // x coordinate
+                        // Same logic as in the circular bar coords test --
+                        // which 5-tuplet of (x, y, r, g, b) is this
+                        // x-coordinate present in? This will determine what it
+                        // SHOULD be (i.e. if this 5-tuplet is supposed to be
+                        // the "top left" of the rectangle being drawn, then
+                        // its x-coordinate should be the left x-coordinate)
+                        switch (floor) {
+                            case 0:
+                            case 1:
+                            case 3:
+                                // tL (0, 3) or bL (1)
+                                equal(v, lx);
+                                break;
+                            default:
+                                // bR (2, 5) or tR (4)
+                                equal(v, rx);
+                        }
+                        break;
+                    case 1:
+                        // y coordinate
+                        switch (floor) {
+                            case 0:
+                            case 3:
+                            case 4:
+                                // tL (0, 3) or tR (4)
+                                equal(v, ty);
+                                break;
+                            default:
+                                // bL (1) or bR (2, 5)
+                                equal(v, by);
+                        }
+                        break;
+                    case 2:
+                        // Red (constant)
+                        equal(v, 0.3);
+                        break;
+                    case 3:
+                        // Green (constant)
+                        equal(v, 0.8);
+                        break;
+                    case 4:
+                        // Blue (constant)
+                        equal(v, 0.9);
+                        break;
+                    default:
+                        throw new Error(
+                            "If this is encountered, something went " +
+                                "very wrong."
+                        );
+                }
+            });
+        });
     });
 });

--- a/tests/test-empress.js
+++ b/tests/test-empress.js
@@ -1084,7 +1084,9 @@ require(["jquery", "UtilitiesForTesting", "util", "chroma"], function (
         test("Test _addCircularBarCoords", function () {
             /**
              * Utility function for checking that an x or y value is what it
-             * should be.
+             * should be. See the comments later on in this test (before
+             * iterating through coords) for details on how coordinates are
+             * added in _addCircularBarCoords().
              *
              * The use of 200 and 100 (for the outer and inner radius,
              * respectively) and of 0 for the node angle, pi / 2 for the
@@ -1176,12 +1178,12 @@ require(["jquery", "UtilitiesForTesting", "util", "chroma"], function (
             ]);
             // Each call of _addTriangleCoords() draws a rectangle with two
             // triangles. This involves adding 6 positions to coords, and since
-            // positions take up 5 spaces in an array here ([x, y, r, g, b]),
+            // positions take up 5 spaces in an array here (x, y, r, g, b),
             // and since _addCircularBarCoords() creates two rectangles (four
             // triangles), coords should contain 6*5 = 30 * 2 = 60 + 1 = 61
             // elements. (The + 1 is for the preexisting thing in the array --
-            // just checking that coords isn't completely overwritten or
-            // anything.)
+            // it's in this test just to check that the input coords array
+            // is appended to, not overwritten.)
             equal(coords.length, 61);
 
             // Check the actual coordinate values.
@@ -1194,7 +1196,10 @@ require(["jquery", "UtilitiesForTesting", "util", "chroma"], function (
             //    |  \ |
             //    bL--bR
             //
-            // These two triangles are added to coords in the following order:
+            // The position information for these two triangles are added to
+            // coords in the following order. (This results in 6*5 = 30 values
+            // being added to coords, since each of these positions has its
+            // own x, y, r, g, b.)
             //
             // 1. tL -> bL -> bR
             // 2. tL -> tR -> bR
@@ -1260,6 +1265,11 @@ require(["jquery", "UtilitiesForTesting", "util", "chroma"], function (
                             // preexisting value.
                             equal(v, 0.75);
                             break;
+                        default:
+                            throw new Error(
+                                "If this is encountered, something went " +
+                                "very wrong."
+                            );
                     }
                 }
             });

--- a/tests/utilities-for-testing.js
+++ b/tests/utilities-for-testing.js
@@ -177,11 +177,12 @@ define(["Empress", "BPTree", "BiomTable"], function (
      * Calls .toFixed() on two numbers with a specified "digits" value and then
      * asserts the results' equality.
      *
-     * I'm gonna be honest, I feel like I've written this function five times
-     * for this project. I can't find this anywhere in this branch, so I
-     * suspect that one of the incoming PRs contains something sort of like
-     * this. If and when it comes to that, we may want to standardize things to
-     * just use this function.
+     * I already wrote something kind of like this for the JS layout tests --
+     * see the toFixedIfy() and approxDeepEqual() functions defined at the top
+     * of test-layouts-util.js as of writing. However, that branch is not
+     * merged into master yet, and this addresses a slightly simpler use case
+     * (just comparing individual numbers, not arrays of numbers). Eventually
+     * we may want to combine these functions, but this should be ok for now.
      *
      * @param {Number} n1
      * @param {Number} n2

--- a/tests/utilities-for-testing.js
+++ b/tests/utilities-for-testing.js
@@ -173,5 +173,27 @@ define(["Empress", "BPTree", "BiomTable"], function (
         };
     }
 
-    return { getTestData: getTestData };
+    /**
+     * Calls .toFixed() on two numbers with a specified "digits" value and then
+     * asserts the results' equality.
+     *
+     * I'm gonna be honest, I feel like I've written this function five times
+     * for this project. I can't find this anywhere in this branch, so I
+     * suspect that one of the incoming PRs contains something sort of like
+     * this. If and when it comes to that, we may want to standardize things to
+     * just use this function.
+     *
+     * @param {Number} n1
+     * @param {Number} n2
+     * @param {Number} digits Will be passed to .toFixed(). Named this way
+     *                        because the corresponding parameter in .toFixed()
+     *                        is also called "digits".
+     */
+    function approxEqual(n1, n2, digits = 4) {
+        var n1f = n1.toFixed(digits);
+        var n2f = n2.toFixed(digits);
+        equal(n1f, n2f);
+    }
+
+    return { getTestData: getTestData, approxEqual: approxEqual };
 });


### PR DESCRIPTION
Closes #297 and closes #343.

This should probably not be merged until #345 and #340 are, but this branch does work in case people want to use this functionality.

Thanks!

### Issues we should probably discuss

- Barplot lengths are still in arbitrary units, so a barplot with length "100" looks thinner in the moving pictures circular layout than in the rectangular layout. Standardizing these somewhat should be possible, but I wanted to avoid doing that until #345 is in (to avoid having to redo the work to accommodate JS layouts).

- Circular layout bars are drawn here by drawing two rectangles (reusing an image I posted [here](https://github.com/biocore/empress/issues/297#issuecomment-676949805)) --
  ![image](https://user-images.githubusercontent.com/4177727/90934046-7b926980-e3b5-11ea-987b-c64d7450d7a8.png)
  We may want to smooth this out, and look at the number of tips in the tree to determine how many rectangles to draw (e.g. use ~15 rectangles for tiny trees like the one above, and only 1 rectangle for massive EMP-scale trees). Or we could just leave this as is until the future, when we'd ideally have a shader draw these as actual curved sections.

- Although the functions that add the coordinates for individual bars (in both rect/circular layouts) are now tested, `addFMBarplotLayerCoords()` and `addSMBarplotLayerCoords()` are still untested. Testing these is going to be a bit time-consuming -- testing the trig stuff gets really annoying really quickly (see e.g. the `_addCircularBarCoords()` test here...), so I think it makes sense to defer testing these until we agree on how many rectangles to use for approximating a curve (per the above point).