### PR TITLE
Support ignoring branch lengths during layout; update tree properties panel UI; some minor clade collapsing changes

### DIFF
--- a/empress/support_files/css/empress.css
+++ b/empress/support_files/css/empress.css
@@ -679,3 +679,8 @@ p.side-header button:hover,
 .selected-metadata-choice {
     background-color: #333 !important;
 }
+
+.side-panel-inner-header {
+    font-weight: bold;
+    justify-content: center !important;
+}

--- a/empress/support_files/css/empress.css
+++ b/empress/support_files/css/empress.css
@@ -683,4 +683,6 @@ p.side-header button:hover,
 .side-panel-inner-header {
     font-weight: bold;
     justify-content: center !important;
+    margin-top: 0;
+    margin-bottom: 0;
 }

--- a/empress/support_files/js/bp-tree.js
+++ b/empress/support_files/js/bp-tree.js
@@ -629,14 +629,19 @@ define(["ByteArray", "underscore"], function (ByteArray, _) {
      *
      * @param {Number} start The postorder position of a node
      * @param {Number} end The postorder position of a node
+     * @param {Boolean} ignoreLengths If truthy, treat all node lengths as 1;
+     *                                if falsy, actually consider node lengths
      *
      * @return {Number} the sum of length from start to end
      */
-    BPTree.prototype.getTotalLength = function (start, end) {
+    BPTree.prototype.getTotalLength = function (start, end, ignoreLengths) {
         var curNode = start;
         var totalLength = 0;
         while (curNode !== end) {
-            totalLength += this.length(this.postorderselect(curNode));
+            var nodeLen = ignoreLengths
+                ? 1
+                : this.length(this.postorderselect(curNode));
+            totalLength += nodeLen;
             curNode = this.parent(this.postorderselect(curNode));
             if (curNode === -1) {
                 throw "Node " + start + " must be a descendant of " + end;

--- a/empress/support_files/js/bp-tree.js
+++ b/empress/support_files/js/bp-tree.js
@@ -638,11 +638,10 @@ define(["ByteArray", "underscore"], function (ByteArray, _) {
         var curNode = start;
         var totalLength = 0;
         while (curNode !== end) {
-            var nodeLen = ignoreLengths
-                ? 1
-                : this.length(this.postorderselect(curNode));
+            var popos = this.postorderselect(curNode);
+            var nodeLen = ignoreLengths ? 1 : this.length(popos);
             totalLength += nodeLen;
-            curNode = this.parent(this.postorderselect(curNode));
+            curNode = this.parent(popos);
             if (curNode === -1) {
                 throw "Node " + start + " must be a descendant of " + end;
             }

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -2244,16 +2244,12 @@ define([
         var supported = this._barplotPanel.updateLayoutAvailability(
             this._currentLayout
         );
-        // TODO: don't call drawTree() from either of these barplot
-        // funcs, since it'll get called in centerLayoutAvgPoint anyway
         if (!supported && this._barplotsDrawn) {
             this.undrawBarplots();
         } else if (supported && this._barplotPanel.enabled) {
             this.drawBarplots(this._barplotPanel.layers);
         }
-        // recenter viewing window
-        // Note: this function calls drawTree()
-        this.centerLayoutAvgPoint();
+        this.drawTree();
     };
 
     /**
@@ -2265,6 +2261,11 @@ define([
                 // get new layout
                 this._currentLayout = newLayout;
                 this.reLayout();
+                // recenter viewing window
+                // NOTE: this function calls drawTree(), which is redundant
+                // since reLayout() already called it. Would be good to
+                // minimize redundant calls to that.
+                this.centerLayoutAvgPoint();
             } else {
                 // This should never happen under normal circumstances (the
                 // input to this function should always be an existing layout
@@ -2762,10 +2763,6 @@ define([
 
         // step 4)
         this.createCollapsedCladeShape(rootNode);
-
-        // We set the root of the clade to default otherwise, the branch that
-        // connects the root clade to its parent will still be colored
-        this.setNodeInfo(rootNode, "color", this.DEFAULT_COLOR);
     };
 
     /**

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -309,7 +309,7 @@ define([
          *
          * This stores the group membership of a node. -1 means the node doesn't
          * belong to a group. This array is used to collapse clades by search
-         * for clades in this array that share the same group membershi[.
+         * for clades in this array that share the same group membership.
          */
         this._group = new Array(this._tree.size + 1).fill(-1);
     }
@@ -2433,21 +2433,16 @@ define([
     /**
      * Collapses all clades that share the same color into a quadrilateral.
      *
-     * Note: if a clade contains a node with DEFAULT_COLOR it will not be
-     *       collapsed
+     * NOTE: Previously, this checked this._collapsedClades to see if there
+     * were any "cached" clades. I've removed this for now because it's
+     * possible for the layout to stay the same but the clades still to
+     * need updating (e.g. if the "ignore lengths" setting of Empress
+     * changes). If collapsing clades is a bottleneck, we could try to add
+     * back caching.
      *
      * @return{Boolean} true if at least one clade was collapse. false otherwise
      */
     Empress.prototype.collapseClades = function () {
-        // first check if any collapsed clades have been cached
-        // TODO: the "ignoreLengths" checkbox breaks / is broken by this.
-        // Fix that!
-        if (Object.keys(this._collapsedClades).length != 0) {
-            for (var cladeRoot in this._collapsedClades) {
-                this.createCollapsedCladeShape(cladeRoot);
-            }
-            return;
-        }
         // The following algorithm consists of two parts: 1) find all clades
         // whose member nodes have the same color, 2) collapse the clades
 
@@ -2483,8 +2478,6 @@ define([
         // collaped.
         // Collapsing a clade will set the .visible property of members to
         // false and will then be skipped in the for loop.
-        // Note: if the root of a clade has DEFUALT_COLOR then it will not be
-        // collapsed (since all of its children will also have DEFAULT_COLOR)
         var inorder = this._tree.inOrderNodes();
         for (var node in inorder) {
             node = inorder[node];
@@ -2663,8 +2656,8 @@ define([
      * Collapse the clade at rootNode
      *
      * This method will set the .visible property for all nodes in the clade
-     * (execpt the root) to false. Also, the color of rootNode will be set to
-     * DEFAULT_COLOR and this._collapsedCladeBuffer will be modified.
+     * (except the root) to false. Also, this._collapsedCladeBuffer will be
+     * updated.
      *
      * Note: This method will cache the clade information. So, as long as
      *       the collapsed clades aren't changed, you do not need to call this

--- a/empress/support_files/js/layouts-util.js
+++ b/empress/support_files/js/layouts-util.js
@@ -89,12 +89,11 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
         // iterates in preorder
         var parent;
         for (i = 2; i <= tree.size; i++) {
-            var node = tree.postorder(tree.preorderselect(i));
-            parent = tree.postorder(tree.parent(tree.preorderselect(i)));
+            var prepos = tree.preorderselect(i);
+            var node = tree.postorder(prepos);
+            parent = tree.postorder(tree.parent(prepos));
 
-            var nodeLen = ignoreLengths
-                ? 1
-                : tree.length(tree.preorderselect(i));
+            var nodeLen = ignoreLengths ? 1 : tree.length(prepos);
             xCoord[node] = xCoord[parent] + nodeLen;
             if (maxWidth < xCoord[node]) {
                 maxWidth = xCoord[node];
@@ -314,15 +313,14 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
         // Iterate over the tree in preorder, assigning radii
         // (The "i = 2" skips the root of the tree; its radius is implicitly 0)
         for (i = 2; i <= tree.size; i++) {
+            var prepos = tree.preorderselect(i);
             // Get the postorder position of this node, which we'll use when
             // writing to the radius array (which is stored in postorder, as
             // are the remainder of the "result" arrays defined above)
-            var node = tree.postorder(tree.preorderselect(i));
-            var parent = tree.postorder(tree.parent(tree.preorderselect(i)));
+            var node = tree.postorder(prepos);
+            var parent = tree.postorder(tree.parent(prepos));
 
-            var nodeLen = ignoreLengths
-                ? 1
-                : tree.length(tree.preorderselect(i));
+            var nodeLen = ignoreLengths ? 1 : tree.length(prepos);
             radius[node] = radius[parent] + nodeLen;
         }
 
@@ -474,6 +472,7 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
             y1 = 0,
             a = 0,
             da = angle;
+        // NOTE: x2 will always be 0, since sin(0) = 0.
         var rootLen = ignoreLengths ? 1 : tree.length(n);
         var x2 = x1 + rootLen * Math.sin(a);
         var y2 = y1 + rootLen * Math.cos(a);

--- a/empress/support_files/js/layouts-util.js
+++ b/empress/support_files/js/layouts-util.js
@@ -42,7 +42,13 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
      *                  maps to an Array where data for each node is stored in
      *                  postorder. yScalingFactor maps to a Number.
      */
-    function rectangularLayout(tree, width, height, normalize = true, ignoreLengths = false) {
+    function rectangularLayout(
+        tree,
+        width,
+        height,
+        ignoreLengths,
+        normalize = true
+    ) {
         // NOTE: This doesn't draw a horizontal line leading to the root "node"
         // of the graph. See https://github.com/biocore/empress/issues/141 for
         // context.
@@ -86,7 +92,9 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
             var node = tree.postorder(tree.preorderselect(i));
             parent = tree.postorder(tree.parent(tree.preorderselect(i)));
 
-            var nodeLen = ignoreLengths ? 1 : tree.length(tree.preorderselect(i));
+            var nodeLen = ignoreLengths
+                ? 1
+                : tree.length(tree.preorderselect(i));
             xCoord[node] = xCoord[parent] + nodeLen;
             if (maxWidth < xCoord[node]) {
                 maxWidth = xCoord[node];
@@ -253,9 +261,9 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
         tree,
         width,
         height,
+        ignoreLengths,
         normalize = true,
-        startAngle = 0,
-        ignoreLengths = false
+        startAngle = 0
     ) {
         // Set up arrays we're going to store the results in
         var x0 = new Array(tree.size + 1).fill(0);
@@ -311,12 +319,11 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
             // are the remainder of the "result" arrays defined above)
             var node = tree.postorder(tree.preorderselect(i));
             var parent = tree.postorder(tree.parent(tree.preorderselect(i)));
-            if (ignoreLengths) {
-                radius[node] = radius[parent] + 1;
-            } else {
-                radius[node] =
-                    radius[parent] + tree.length(tree.preorderselect(i));
-            }
+
+            var nodeLen = ignoreLengths
+                ? 1
+                : tree.length(tree.preorderselect(i));
+            radius[node] = radius[parent] + nodeLen;
         }
 
         // Now that we have the polar coordinates of the nodes, convert them to
@@ -448,7 +455,13 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
      *                  Each of these properties maps to an Array where data for
      *                  each node is stored in postorder.
      */
-    function unrootedLayout(tree, width, height, normalize = true, ignoreLengths = false) {
+    function unrootedLayout(
+        tree,
+        width,
+        height,
+        ignoreLengths,
+        normalize = true
+    ) {
         var angle = (2 * Math.PI) / tree.numleaves();
         var x1Arr = new Array(tree.size + 1);
         var x2Arr = new Array(tree.size + 1).fill(0);

--- a/empress/support_files/js/layouts-util.js
+++ b/empress/support_files/js/layouts-util.js
@@ -27,11 +27,11 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
      *                      displayed.
      * @param {Float} height Height of the canvas where the tree will be
      *                       displayed.
-     * @param {Boolean} normalize If true, then the tree will be scaled up to
-     *                            fill the bounds of width and height.
      * @param {Boolean} ignoreLengths If falsy, branch lengths are used in the
      *                                layout; otherwise, a uniform length of 1
      *                                is used.
+     * @param {Boolean} normalize If true, then the tree will be scaled up to
+     *                            fill the bounds of width and height.
      * @return {Object} Object with the following properties:
      *                   -xCoords
      *                   -yCoords
@@ -230,6 +230,9 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
      *                      displayed.
      * @param {Float} height Height of the canvas where the tree will be
      *                       displayed.
+     * @param {Boolean} ignoreLengths If falsy, branch lengths are used in the
+     *                                layout; otherwise, a uniform length of 1
+     *                                is used.
      * @param {Boolean} normalize If true, then the tree will be scaled up to
      *                            fill the bounds of width and height.
      * @param {Float} startAngle The first tip in the tree visited is assigned
@@ -240,9 +243,6 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
      *                           that circle, etc.). I believe this is
      *                           analogous to how the "rotation" parameter of
      *                           iTOL works.
-     * @param {Boolean} ignoreLengths If falsy, branch lengths are used in the
-     *                                layout; otherwise, a uniform length of 1
-     *                                is used.
      * @return {Object} Object with the following properties:
      *                   -x0, y0 ("starting point" x and y)
      *                   -x1, y1 ("ending point" x and y)
@@ -442,11 +442,11 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
      *                      displayed.
      * @param {Float} height Height of the canvas where the tree will be
      *                       displayed.
-     * @param {Boolean} normalize If true, then the tree will be scaled up to
-     *                            fill the bounds of width and height.
      * @param {Boolean} ignoreLengths If falsy, branch lengths are used in the
      *                                layout; otherwise, a uniform length of 1
      *                                is used.
+     * @param {Boolean} normalize If true, then the tree will be scaled up to
+     *                            fill the bounds of width and height.
      * @return {Object} Object with the following properties:
      *                   -xCoords
      *                   -yCoords

--- a/empress/support_files/js/layouts-util.js
+++ b/empress/support_files/js/layouts-util.js
@@ -29,6 +29,9 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
      *                       displayed.
      * @param {Boolean} normalize If true, then the tree will be scaled up to
      *                            fill the bounds of width and height.
+     * @param {Boolean} ignoreLengths If falsy, branch lengths are used in the
+     *                                layout; otherwise, a uniform length of 1
+     *                                is used.
      * @return {Object} Object with the following properties:
      *                   -xCoords
      *                   -yCoords
@@ -39,7 +42,7 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
      *                  maps to an Array where data for each node is stored in
      *                  postorder. yScalingFactor maps to a Number.
      */
-    function rectangularLayout(tree, width, height, normalize = true) {
+    function rectangularLayout(tree, width, height, normalize = true, ignoreLengths = false) {
         // NOTE: This doesn't draw a horizontal line leading to the root "node"
         // of the graph. See https://github.com/biocore/empress/issues/141 for
         // context.
@@ -83,7 +86,8 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
             var node = tree.postorder(tree.preorderselect(i));
             parent = tree.postorder(tree.parent(tree.preorderselect(i)));
 
-            xCoord[node] = xCoord[parent] + tree.length(tree.preorderselect(i));
+            var nodeLen = ignoreLengths ? 1 : tree.length(tree.preorderselect(i));
+            xCoord[node] = xCoord[parent] + nodeLen;
             if (maxWidth < xCoord[node]) {
                 maxWidth = xCoord[node];
             }
@@ -435,13 +439,16 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
      *                       displayed.
      * @param {Boolean} normalize If true, then the tree will be scaled up to
      *                            fill the bounds of width and height.
+     * @param {Boolean} ignoreLengths If falsy, branch lengths are used in the
+     *                                layout; otherwise, a uniform length of 1
+     *                                is used.
      * @return {Object} Object with the following properties:
      *                   -xCoords
      *                   -yCoords
      *                  Each of these properties maps to an Array where data for
      *                  each node is stored in postorder.
      */
-    function unrootedLayout(tree, width, height, normalize = true) {
+    function unrootedLayout(tree, width, height, normalize = true, ignoreLengths = false) {
         var angle = (2 * Math.PI) / tree.numleaves();
         var x1Arr = new Array(tree.size + 1);
         var x2Arr = new Array(tree.size + 1).fill(0);
@@ -454,8 +461,9 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
             y1 = 0,
             a = 0,
             da = angle;
-        var x2 = x1 + tree.length(n) * Math.sin(a);
-        var y2 = y1 + tree.length(n) * Math.cos(a);
+        var rootLen = ignoreLengths ? 1 : tree.length(n);
+        var x2 = x1 + rootLen * Math.sin(a);
+        var y2 = y1 + rootLen * Math.cos(a);
         x1Arr[tree.size] = x1;
         x2Arr[tree.size] = x2;
         y1Arr[tree.size] = y1;
@@ -482,8 +490,9 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
             a += (tree.getNumTips(node) * da) / 2;
 
             n = tree.postorderselect(node);
-            x2 = x1 + tree.length(n) * Math.sin(a);
-            y2 = y1 + tree.length(n) * Math.cos(a);
+            var nodeLen = ignoreLengths ? 1 : tree.length(n);
+            x2 = x1 + nodeLen * Math.sin(a);
+            y2 = y1 + nodeLen * Math.cos(a);
             x1Arr[node] = x1;
             x2Arr[node] = x2;
             y1Arr[node] = y1;

--- a/empress/support_files/js/side-panel-handler.js
+++ b/empress/support_files/js/side-panel-handler.js
@@ -38,6 +38,7 @@ define(["underscore", "Colorer", "util"], function (_, Colorer, util) {
         this.recenterBtn = document.getElementById("center-tree-btn");
         this.focusOnNodeChk = document.getElementById("focus-on-node-chk");
         this.absentTipChk = document.getElementById("absent-tip-chk");
+        this.ignoreLengthsChk = document.getElementById("ignore-lengths-chk");
 
         this.focusOnNodeChk.onclick = function () {
             empress.focusOnSelectedNode = this.checked;
@@ -49,6 +50,11 @@ define(["underscore", "Colorer", "util"], function (_, Colorer, util) {
             if (scope.sChk.checked) {
                 scope.sUpdateBtn.click();
             }
+        };
+        this.ignoreLengthsChk.onclick = function () {
+            empress.ignoreLengths = this.checked;
+            console.log("ignoreLengths is " + empress.ignoreLengths);
+            empress.reLayout();
         };
 
         // sample GUI components

--- a/empress/support_files/js/side-panel-handler.js
+++ b/empress/support_files/js/side-panel-handler.js
@@ -53,7 +53,6 @@ define(["underscore", "Colorer", "util"], function (_, Colorer, util) {
         };
         this.ignoreLengthsChk.onclick = function () {
             empress.ignoreLengths = this.checked;
-            console.log("ignoreLengths is " + empress.ignoreLengths);
             empress.reLayout();
         };
 

--- a/empress/support_files/templates/side-panel.html
+++ b/empress/support_files/templates/side-panel.html
@@ -238,8 +238,16 @@
     If checked, this draws circles at the positions of all tree nodes
     which had a specified name in the input Newick file.
   </p>
-  <p class="side-panel-notes">
-    Clade Collapse Method
+  <hr />
+  <p>
+    <button id="center-tree-btn">Reset Camera</button>
+  </p>
+  <p class="side-panel-notes indented">
+    Repositions the camera at the center of the tree.
+  </p>
+  <hr />
+  <p class="side-panel-inner-header">
+    Clade Collapsing Method
   </p>
   <p>
     <label for="normal">Normal</label>
@@ -260,12 +268,7 @@
     the shape will be symmetric w.r.t. to the root of the clade. This option
     only applies to the Rectangular and Circular layouts.
   </p>
-  <p>
-    <button id="center-tree-btn">Reset Camera</button>
-  </p>
-  <p class="side-panel-notes indented">
-    Repositions the camera at the center of the tree.
-  </p>
+  <hr />
   <p>
     <label for="focus-on-node-chk">Focus on Selected Nodes?</label>
     <input id="focus-on-node-chk" type="checkbox" checked="true"
@@ -275,6 +278,7 @@
     If checked, the camera is focused on the node after an id is found via
     the searchbox, or when an arrow is clicked in a biplot.
   </p>
+  <hr />
   <p>
     <label for="absent-tip-chk">Ignore Absent Tips?</label>
     <input id="absent-tip-chk" type="checkbox" checked="true"

--- a/empress/support_files/templates/side-panel.html
+++ b/empress/support_files/templates/side-panel.html
@@ -257,8 +257,8 @@
            class="empress-input">
   </p>
   <p class="side-panel-notes indented">
-    If checked, the camera is focused on a node that has been selected via
-    searching by name or by click on an arrow in an Emperor biplot.
+    If checked, the camera will automatically focus on nodes that are selected
+    via searching by name or by clicking on an arrow in a biplot.
   </p>
   <hr />
   <p class="side-panel-inner-header">

--- a/empress/support_files/templates/side-panel.html
+++ b/empress/support_files/templates/side-panel.html
@@ -229,6 +229,9 @@
 <!-- Global Tree properties -->
 <button class="side-header collapsible">Tree Properties</button>
 <div class="side-content control hidden">
+  <p class="side-panel-inner-header">
+    Node circles
+  </p>
   <p>
     <label for="display-nodes-chk">Show node circles?</label>
     <input id="display-nodes-chk" type="checkbox" checked="true"
@@ -239,15 +242,27 @@
     which had a specified name in the input Newick file.
   </p>
   <hr />
+  <p class="side-panel-inner-header">
+    Camera
+  </p>
   <p>
     <button id="center-tree-btn">Reset Camera</button>
   </p>
   <p class="side-panel-notes indented">
     Repositions the camera at the center of the tree.
   </p>
+  <p>
+    <label for="focus-on-node-chk">Focus on selected nodes?</label>
+    <input id="focus-on-node-chk" type="checkbox" checked="true"
+           class="empress-input">
+  </p>
+  <p class="side-panel-notes indented">
+    If checked, the camera is focused on a node that has been selected via
+    searching by name or by click on an arrow in an Emperor biplot.
+  </p>
   <hr />
   <p class="side-panel-inner-header">
-    Clade Collapsing Method
+    Clade collapsing method
   </p>
   <p>
     <label for="normal">Normal</label>
@@ -269,27 +284,20 @@
     only applies to the Rectangular and Circular layouts.
   </p>
   <hr />
-  <p>
-    <label for="focus-on-node-chk">Focus on Selected Nodes?</label>
-    <input id="focus-on-node-chk" type="checkbox" checked="true"
-           class="empress-input">
+  <p class="side-panel-inner-header">
+    Tree coloring
   </p>
-  <p class="side-panel-notes indented">
-    If checked, the camera is focused on the node after an id is found via
-    the searchbox, or when an arrow is clicked in a biplot.
-  </p>
-  <hr />
   <p>
-    <label for="absent-tip-chk">Ignore Absent Tips?</label>
+    <label for="absent-tip-chk">Ignore absent tips?</label>
     <input id="absent-tip-chk" type="checkbox" checked="true"
            class="empress-input">
   </p>
   <p class="side-panel-notes indented">
     If checked, tips not represented in the current sample selection are
     ignored when propagating the color of a clade. Applies to sample metadata
-    coloring, animations, and sample selections in Emperor. We recommend to
-    change this setting before starting an animation, otherwise this setting
-    might be partially applied.
+    coloring, animations, and sample selections in Emperor. We recommend
+    changing this setting before starting an animation; otherwise, this setting
+    may only be partially applied throughout the animation.
   </p>
 
 </div>

--- a/empress/support_files/templates/side-panel.html
+++ b/empress/support_files/templates/side-panel.html
@@ -262,6 +262,19 @@
   </p>
   <hr />
   <p class="side-panel-inner-header">
+    Layout options
+  </p>
+  <p>
+    <label for="ignore-lengths-chk">Ignore node lengths?</label>
+    <input id="ignore-lengths-chk" type="checkbox" class="empress-input">
+  </p>
+  <p class="side-panel-notes indented">
+    If checked, node lengths are ignored when drawing the tree. Note that the
+    root node's length is always ignored, regardless of if this is checked or
+    not.
+  </p>
+  <hr />
+  <p class="side-panel-inner-header">
     Clade collapsing method
   </p>
   <p>

--- a/empress/support_files/templates/side-panel.html
+++ b/empress/support_files/templates/side-panel.html
@@ -265,11 +265,11 @@
     Layout options
   </p>
   <p>
-    <label for="ignore-lengths-chk">Ignore node lengths?</label>
+    <label for="ignore-lengths-chk">Ignore branch lengths?</label>
     <input id="ignore-lengths-chk" type="checkbox" class="empress-input">
   </p>
   <p class="side-panel-notes indented">
-    If checked, node lengths are ignored when drawing the tree. Note that the
+    If checked, branch lengths are ignored when drawing the tree. Note that the
     root node's length is always ignored, regardless of if this is checked or
     not.
   </p>

--- a/tests/test-bp-tree.js
+++ b/tests/test-bp-tree.js
@@ -636,6 +636,20 @@ require(["jquery", "ByteArray", "BPTree"], function ($, ByteArray, BPTree) {
                 "Total length from 3 to 11 should be 12."
             );
 
+            equal(
+                this.bpObj.getTotalLength(3, 11, true),
+                3,
+                "Total length from 3 to 11, ignoring lengths, should be 3."
+            );
+
+            // 10 is a child of 11 (the root node), so there should just be a
+            // length of 1 between them
+            equal(
+                this.bpObj.getTotalLength(10, 11, true),
+                1,
+                "Total length from 10 to 11, ignoring lengths, should be 1."
+            );
+
             throws(function () {
                 this.bpObj.getTotalLength(5, 3);
             });

--- a/tests/test-layouts-util.js
+++ b/tests/test-layouts-util.js
@@ -70,7 +70,7 @@ require([
         });
 
         test("Test rectangular layout", function () {
-            var obs = LayoutsUtil.rectangularLayout(this.tree, 1, 1, false);
+            var obs = LayoutsUtil.rectangularLayout(this.tree, 1, 1, false, false);
             /* Why do these coordinates look like this?
              *
              * There are a few steps to the layout.
@@ -140,6 +140,7 @@ require([
                 this.straightLineTree,
                 1,
                 1,
+                false,
                 false
             );
 
@@ -158,6 +159,7 @@ require([
                 this.noRootLength,
                 1,
                 1,
+                false,
                 false
             );
 
@@ -175,6 +177,7 @@ require([
                 this.circLayoutTestTree,
                 5,
                 5,
+                false,
                 false
             );
             // Check that there isn't extra junk included in obs' output
@@ -269,6 +272,7 @@ require([
                 this.circLayoutTestTree,
                 1,
                 1,
+                false,
                 false
             );
             // We skip root since we don't care about its length.
@@ -286,7 +290,7 @@ require([
             // length, the output data should be exactly the same.
             var trees = [this.straightLineTree, this.noRootLength];
             _.each(trees, function (tree) {
-                var obs = LayoutsUtil.circularLayout(tree, 1, 1, false);
+                var obs = LayoutsUtil.circularLayout(tree, 1, 1, false, false);
                 // The tree looks like:
                 // root -- a ---- b
                 deepEqual(obs.x0, [0, 1, 0, 0], "x0");
@@ -310,9 +314,8 @@ require([
                     tree,
                     1,
                     1,
-                    false,
-                    0,
-                    true
+                    true,
+                    false
                 );
                 // The tree looks like: (note the equal branch lengths)
                 // root -- a -- b
@@ -335,6 +338,7 @@ require([
                 this.straightLineTree,
                 1,
                 1,
+                false,
                 false,
                 piover2
             );
@@ -395,9 +399,9 @@ require([
                 this.circLayoutTestTree,
                 1,
                 1,
+                true,
                 false,
-                3 * Math.PI,
-                true
+                3 * Math.PI
             );
             // Should be equal to (# non-root ancestor nodes)*cos(node angle)
             // ... For d and c, there's only 1 non-root ancestor node. For all
@@ -473,7 +477,7 @@ require([
         });
 
         test("Test unrooted layout", function () {
-            var obs = LayoutsUtil.unrootedLayout(this.tree, 1, 1);
+            var obs = LayoutsUtil.unrootedLayout(this.tree, 1, 1, false);
             var exp = {
                 xCoord: [
                     0,

--- a/tests/test-layouts-util.js
+++ b/tests/test-layouts-util.js
@@ -70,7 +70,13 @@ require([
         });
 
         test("Test rectangular layout", function () {
-            var obs = LayoutsUtil.rectangularLayout(this.tree, 1, 1, false, false);
+            var obs = LayoutsUtil.rectangularLayout(
+                this.tree,
+                1,
+                1,
+                false,
+                false
+            );
             /* Why do these coordinates look like this?
              *
              * There are a few steps to the layout.
@@ -154,6 +160,27 @@ require([
             deepEqual(obs, exp);
         });
 
+        test("Test straightline tree rectangular layout: ignoreLengths", function () {
+            var obs = LayoutsUtil.rectangularLayout(
+                this.straightLineTree,
+                1,
+                1,
+                true,
+                false
+            );
+
+            // The only difference in output is that the one tip node in the
+            // tree (at postorder position 1) is at x = 2, not x = 3.
+            var exp = {
+                highestChildYr: [undefined, undefined, 0, 0],
+                lowestChildYr: [undefined, undefined, 0, 0],
+                xCoord: [0, 2, 1, 0],
+                yCoord: [0, 0, 0, 0],
+                yScalingFactor: 1,
+            };
+            deepEqual(obs, exp);
+        });
+
         test("Test missing root length rectangular layout", function () {
             var obs = LayoutsUtil.rectangularLayout(
                 this.noRootLength,
@@ -172,6 +199,7 @@ require([
             };
             deepEqual(obs, exp);
         });
+
         test("Test circular layout", function () {
             var obs = LayoutsUtil.circularLayout(
                 this.circLayoutTestTree,
@@ -310,13 +338,7 @@ require([
         test("Test straightline tree circular layout: ignoreLengths", function () {
             var trees = [this.straightLineTree, this.noRootLength];
             _.each(trees, function (tree) {
-                var obs = LayoutsUtil.circularLayout(
-                    tree,
-                    1,
-                    1,
-                    true,
-                    false
-                );
+                var obs = LayoutsUtil.circularLayout(tree, 1, 1, true, false);
                 // The tree looks like: (note the equal branch lengths)
                 // root -- a -- b
                 deepEqual(obs.x0, [0, 1, 0, 0], "x0");


### PR DESCRIPTION
Closes #271. Also wound up closing #321 (ran into it along the way).

![ignoooore](https://user-images.githubusercontent.com/4177727/91789040-97bab580-ebc2-11ea-89fe-64a600596a77.gif)

The main challenge here was making sure that updating the "ignore lengths?" setting didn't mess with the tree state. This mostly wasn't a problem, but I had to mess around some with how clade collapsing works (since as far as I can tell the previous clade collapsing stuff assumed that clades computed for a given layout could be cached; but here the same layout can have multiple ways of collapsing since the node coordinates vary based on the ignore lengths setting). I believe this works as it should now, but I'm not very familiar with this part of this code.

Other thing we should discuss -- the UI says that "the root node's length is always ignored", but it looks like the unrooted layout uses the root node's length at one point. Since we don't require that the root node has a valid or even specified length, we should discuss this to see what to do.
 
Thanks!