### PR TITLE
ENH: Link emperor double-click event and add timer cancelation

### DIFF
--- a/empress/support_files/js/node-click-callback.js
+++ b/empress/support_files/js/node-click-callback.js
@@ -22,3 +22,31 @@ ec.sceneViews[0].on("click", function (name, object) {
 
     empress.showNodeMenuForName(name);
 });
+
+ec.controllers.color.addEventListener("value-double-clicked", function (
+    payload
+) {
+    // cancel any ongoing timers
+    clearTimeout(empress.timer);
+
+    // if there's any coloring setup remove it, and re-enable the update button
+    sPanel.sUpdateBtn.classList.remove("hidden");
+    sPanel.fUpdateBtn.classList.remove("hidden");
+    legend.clear();
+    empress.resetTree();
+
+    var names = _.map(payload.message.group, function (item) {
+        return item.name;
+    });
+    var container = {};
+    container[payload.message.attribute] = names;
+    empress.colorSampleGroups(container);
+
+    // 4 seconds before resetting
+    empress.timer = setTimeout(function () {
+        empress.resetTree();
+        empress.drawTree();
+
+        plotView.needsUpdate = true;
+    }, 4000);
+});

--- a/empress/support_files/js/node-click-callback.js
+++ b/empress/support_files/js/node-click-callback.js
@@ -26,8 +26,18 @@ ec.sceneViews[0].on("click", function (name, object) {
 ec.controllers.color.addEventListener("value-double-clicked", function (
     payload
 ) {
+    // when dealing with a biplot ignore arrow-emitted events
+    if (payload.target.decompositionName() !== 'scatter') {
+        return;
+    }
+
     // cancel any ongoing timers
     clearTimeout(empress.timer);
+
+    // reset emissive settings for all markers since an ongoing timer may have
+    // been cancelled
+    ec.decViews.scatter.setEmissive(0x000000);
+    plotView.needsUpdate = true;
 
     // if there's any coloring setup remove it, and re-enable the update button
     sPanel.sUpdateBtn.classList.remove("hidden");

--- a/empress/support_files/js/node-click-callback.js
+++ b/empress/support_files/js/node-click-callback.js
@@ -27,7 +27,7 @@ ec.controllers.color.addEventListener("value-double-clicked", function (
     payload
 ) {
     // when dealing with a biplot ignore arrow-emitted events
-    if (payload.target.decompositionName() !== 'scatter') {
+    if (payload.target.decompositionName() !== "scatter") {
         return;
     }
 

--- a/empress/support_files/js/selection-callback.js
+++ b/empress/support_files/js/selection-callback.js
@@ -4,6 +4,9 @@
  *
  */
 
+// cancel any ongoing timers
+clearTimeout(empress.timer);
+
 // if there's any coloring setup remove it, and re-enable the update button
 sPanel.sUpdateBtn.classList.remove("hidden");
 sPanel.fUpdateBtn.classList.remove("hidden");
@@ -22,8 +25,8 @@ for (var key in groups) {
 }
 empress.colorSampleGroups(namesOnly);
 
-// 3 seconds before resetting
-setTimeout(function () {
+// 4 seconds before resetting
+empress.timer = setTimeout(function () {
     empress.resetTree();
     empress.drawTree();
 


### PR DESCRIPTION
This adds the ability to double-click on a color category in Emperor and highlighting the tips in the tree represented by that group. This also adds a timer cancellation to prevent problems with sample selections as reported in #197.

![double-click](https://user-images.githubusercontent.com/375307/92145140-a4125e80-edcc-11ea-8f90-65db9e7536ec.gif)


The documentation on the callback is fairly lax but should be improved once the explanation in #319 is merged.