### PR TITLE
Smooth arcs

### DIFF
--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -398,7 +398,7 @@ define([
 
         this.getLayoutInfo();
         this.centerLayoutAvgPoint();
-        // this.drawTree();
+        // centerLayoutAvgPoint() calls drawTree(), so no need to call it here
     };
 
     /**
@@ -855,11 +855,11 @@ define([
                     !this._collapsedClades.hasOwnProperty(node)
                 ) {
                     // An arc will be created for all internal nodes.
-                    // arcs are created by sampling upto 60 small lines along
+                    // arcs are created by sampling up to 60 small lines along
                     // the arc spanned by rotating the line (arcx0, arcy0)
                     // arcendangle - arcstartangle radians. This will create an
-                    // that starts at each internal node's right most child
-                    // and ends on the left most child.
+                    // that starts at each internal node's rightmost child
+                    // and ends on the leftmost child.
                     var arcDeltaAngle =
                         this.getNodeInfo(node, "arcendangle") -
                         this.getNodeInfo(node, "arcstartangle");

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -749,7 +749,7 @@ define([
      * @return {Array}
      */
     Empress.prototype.getCoords = function () {
-        var d = new Date;
+        var d = new Date();
         var tree = this._tree;
 
         // The coordinates (and colors) of the tree's nodes.
@@ -865,7 +865,7 @@ define([
                         this.getNodeInfo(node, "arcendangle") -
                         this.getNodeInfo(node, "arcstartangle");
                     var numSamples = Math.floor(
-                        60 * Math.abs(arcDeltaAngle / (Math.PI))
+                        60 * Math.abs(arcDeltaAngle / Math.PI)
                     );
                     numSamples = numSamples > 0 ? numSamples : 2;
                     var sampleAngle = arcDeltaAngle / numSamples;
@@ -899,6 +899,7 @@ define([
         }
         var dt = new Date();
         console.log("Circ time:", dt.getTime() - d.getTime());
+        console.log("coords length:", coords.length);
         return new Float32Array(coords);
     };
 
@@ -1264,7 +1265,7 @@ define([
                         this.getNodeInfo(node, "arcendangle") -
                         this.getNodeInfo(node, "arcstartangle");
                     var numSamples = Math.floor(
-                        60 * Math.abs(arcDeltaAngle / (Math.PI))
+                        60 * Math.abs(arcDeltaAngle / Math.PI)
                     );
                     numSamples = numSamples > 0 ? numSamples : 2;
                     var sampleAngle = arcDeltaAngle / numSamples;

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -743,6 +743,22 @@ define([
     };
 
     /**
+     * Returns the number of lines/trianges to approximate an arc/wedge given
+     * the total angle of the arc/wedge.
+     *
+     * @param {Number} totalAngle The total angle of the arc/wedge
+     * @return {Number} The number of lines/triangles to approximate the arc
+     *                  or wedge.
+     */
+    Empress.prototype._numSampToApproximate = function(totalAngle) {
+        var numSamples = Math.floor(
+            60 * Math.abs(totalAngle / Math.PI)
+        );
+        numSamples = numSamples >= 2 ? numSamples : 2;
+        return numSamples;
+    } 
+
+    /**
      * Retrieves the coordinate info of the tree.
      *  format of coordinate info: [x, y, red, green, blue, ...]
      *
@@ -863,10 +879,7 @@ define([
                     var arcDeltaAngle =
                         this.getNodeInfo(node, "arcendangle") -
                         this.getNodeInfo(node, "arcstartangle");
-                    var numSamples = Math.floor(
-                        60 * Math.abs(arcDeltaAngle / Math.PI)
-                    );
-                    numSamples = numSamples > 0 ? numSamples : 2;
+                    var numSamples = this._numSampToApproximate(arcDeltaAngle);
                     var sampleAngle = arcDeltaAngle / numSamples;
                     var sX = this.getNodeInfo(node, "arcx0");
                     var sY = this.getNodeInfo(node, "arcy0");
@@ -1260,10 +1273,7 @@ define([
                     var arcDeltaAngle =
                         this.getNodeInfo(node, "arcendangle") -
                         this.getNodeInfo(node, "arcstartangle");
-                    var numSamples = Math.floor(
-                        60 * Math.abs(arcDeltaAngle / Math.PI)
-                    );
-                    numSamples = numSamples > 0 ? numSamples : 2;
+                    var numSamples = this._numSampToApproximate(arcDeltaAngle);
                     var sampleAngle = arcDeltaAngle / numSamples;
                     var sX = this.getNodeInfo(node, "arcx0");
                     var sY = this.getNodeInfo(node, "arcy0");
@@ -2640,11 +2650,12 @@ define([
             cladeInfo.sY = sY;
             cladeInfo.totalAngle = totalAngle;
 
-            // create 15 triangles to approximate sector
-            var deltaAngle = totalAngle / 15;
+            // create triangles to approximate sector
+            var numSamples = this._numSampToApproximate(totalAngle);
+            var deltaAngle = totalAngle / numSamples;
             cos = Math.cos(0);
             sin = Math.sin(0);
-            for (var line = 0; line < 15; line++) {
+            for (var line = 0; line < numSamples; line++) {
                 addPoint(getCoords(rootNode));
 
                 x = sX * cos - sY * sin;

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -855,15 +855,17 @@ define([
                     !this._tree.isleaf(this._tree.postorderselect(node)) &&
                     !this._collapsedClades.hasOwnProperty(node)
                 ) {
-                    // arcs are created by sampling 15 small lines along the
-                    // arc spanned by rotating (arcx0, arcy0), the line whose
-                    // origin is the root of the tree and endpoint is the start
-                    // of the arc, by arcendangle - arcstartangle radians.
+                    // An arc will be created for all internal nodes.
+                    // arcs are created by sampling upto 60 small lines along
+                    // the arc spanned by rotating the line (arcx0, arcy0)
+                    // arcendangle - arcstartangle radians. This will create an
+                    // that starts at each internal node's right most child
+                    // and ends on the left most child.
                     var arcDeltaAngle =
                         this.getNodeInfo(node, "arcendangle") -
                         this.getNodeInfo(node, "arcstartangle");
                     var numSamples = Math.floor(
-                        40 * Math.abs(arcDeltaAngle / (Math.PI))
+                        60 * Math.abs(arcDeltaAngle / (Math.PI))
                     );
                     numSamples = numSamples > 0 ? numSamples : 2;
                     var sampleAngle = arcDeltaAngle / numSamples;
@@ -1252,14 +1254,19 @@ define([
                 // (TODO: this will need to be adapted when the arc is changed
                 // to be a bezier curve)
                 if (!this._tree.isleaf(this._tree.postorderselect(node))) {
-                    // arcs are created by sampling 15 small lines along the
-                    // arc spanned by rotating arcx0, the line whose origin
-                    // is the root of the tree and endpoint is the start of the
-                    // arc, by arcendangle - arcstartangle radians.
-                    var numSamples = 15;
+                    // An arc will be created for all internal nodes.
+                    // arcs are created by sampling upto 60 small lines along
+                    // the arc spanned by rotating the line (arcx0, arcy0)
+                    // arcendangle - arcstartangle radians. This will create an
+                    // that starts at each internal node's right most child
+                    // and ends on the left most child.
                     var arcDeltaAngle =
                         this.getNodeInfo(node, "arcendangle") -
                         this.getNodeInfo(node, "arcstartangle");
+                    var numSamples = Math.floor(
+                        60 * Math.abs(arcDeltaAngle / (Math.PI))
+                    );
+                    numSamples = numSamples > 0 ? numSamples : 2;
                     var sampleAngle = arcDeltaAngle / numSamples;
                     var sX = this.getNodeInfo(node, "arcx0");
                     var sY = this.getNodeInfo(node, "arcy0");

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -743,7 +743,7 @@ define([
     };
 
     /**
-     * Returns the number of lines/trianges to approximate an arc/wedge given
+     * Returns the number of lines/triangles to approximate an arc/wedge given
      * the total angle of the arc/wedge.
      *
      * @param {Number} totalAngle The total angle of the arc/wedge
@@ -752,8 +752,7 @@ define([
      */
     Empress.prototype._numSampToApproximate = function (totalAngle) {
         var numSamples = Math.floor(60 * Math.abs(totalAngle / Math.PI));
-        numSamples = numSamples >= 2 ? numSamples : 2;
-        return numSamples;
+        return numSamples >= 2 ? numSamples : 2;
     };
 
     /**
@@ -872,7 +871,7 @@ define([
                     // arcs are created by sampling up to 60 small lines along
                     // the arc spanned by rotating the line (arcx0, arcy0)
                     // arcendangle - arcstartangle radians. This will create an
-                    // that starts at each internal node's rightmost child
+                    // arc that starts at each internal node's rightmost child
                     // and ends on the leftmost child.
                     var arcDeltaAngle =
                         this.getNodeInfo(node, "arcendangle") -
@@ -1263,11 +1262,7 @@ define([
                 // to be a bezier curve)
                 if (!this._tree.isleaf(this._tree.postorderselect(node))) {
                     // An arc will be created for all internal nodes.
-                    // arcs are created by sampling upto 60 small lines along
-                    // the arc spanned by rotating the line (arcx0, arcy0)
-                    // arcendangle - arcstartangle radians. This will create an
-                    // that starts at each internal node's right most child
-                    // and ends on the left most child.
+                    // See getCoords() for details on how arcs are drawn.
                     var arcDeltaAngle =
                         this.getNodeInfo(node, "arcendangle") -
                         this.getNodeInfo(node, "arcstartangle");
@@ -2651,8 +2646,8 @@ define([
             // create triangles to approximate sector
             var numSamples = this._numSampToApproximate(totalAngle);
             var deltaAngle = totalAngle / numSamples;
-            cos = Math.cos(0);
-            sin = Math.sin(0);
+            cos = 1; // Math.cos(0)
+            sin = 0; // Math.sin(0)
             for (var line = 0; line < numSamples; line++) {
                 addPoint(getCoords(rootNode));
 

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -398,6 +398,7 @@ define([
 
         this.getLayoutInfo();
         this.centerLayoutAvgPoint();
+        // this.drawTree();
     };
 
     /**
@@ -748,6 +749,7 @@ define([
      * @return {Array}
      */
     Empress.prototype.getCoords = function () {
+        var d = new Date;
         var tree = this._tree;
 
         // The coordinates (and colors) of the tree's nodes.
@@ -857,10 +859,13 @@ define([
                     // arc spanned by rotating (arcx0, arcy0), the line whose
                     // origin is the root of the tree and endpoint is the start
                     // of the arc, by arcendangle - arcstartangle radians.
-                    var numSamples = 15;
                     var arcDeltaAngle =
                         this.getNodeInfo(node, "arcendangle") -
                         this.getNodeInfo(node, "arcstartangle");
+                    var numSamples = Math.floor(
+                        40 * Math.abs(arcDeltaAngle / (Math.PI))
+                    );
+                    numSamples = numSamples > 0 ? numSamples : 2;
                     var sampleAngle = arcDeltaAngle / numSamples;
                     var sX = this.getNodeInfo(node, "arcx0");
                     var sY = this.getNodeInfo(node, "arcy0");
@@ -890,6 +895,8 @@ define([
                 addPoint(this.getX(node), this.getY(node));
             }
         }
+        var dt = new Date();
+        console.log("Circ time:", dt.getTime() - d.getTime());
         return new Float32Array(coords);
     };
 
@@ -2249,7 +2256,7 @@ define([
         } else if (supported && this._barplotPanel.enabled) {
             this.drawBarplots(this._barplotPanel.layers);
         }
-        this.drawTree();
+        this.centerLayoutAvgPoint();
     };
 
     /**
@@ -2265,7 +2272,6 @@ define([
                 // NOTE: this function calls drawTree(), which is redundant
                 // since reLayout() already called it. Would be good to
                 // minimize redundant calls to that.
-                this.centerLayoutAvgPoint();
             } else {
                 // This should never happen under normal circumstances (the
                 // input to this function should always be an existing layout

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -72,7 +72,7 @@ define([
          * @type {Array}
          * The default color of the tree
          */
-        this.DEFAULT_COLOR = [0.75, 0.75, 0.75];
+        this.DEFAULT_COLOR = [0, 0, 0];
 
         /**
          * @type {BPTree}

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -2642,8 +2642,8 @@ define([
 
             // create 15 triangles to approximate sector
             var deltaAngle = totalAngle / 15;
-            cos = Math.cos(deltaAngle);
-            sin = Math.sin(deltaAngle);
+            cos = Math.cos(0);
+            sin = Math.sin(0);
             for (var line = 0; line < 15; line++) {
                 addPoint(getCoords(rootNode));
 

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -750,13 +750,11 @@ define([
      * @return {Number} The number of lines/triangles to approximate the arc
      *                  or wedge.
      */
-    Empress.prototype._numSampToApproximate = function(totalAngle) {
-        var numSamples = Math.floor(
-            60 * Math.abs(totalAngle / Math.PI)
-        );
+    Empress.prototype._numSampToApproximate = function (totalAngle) {
+        var numSamples = Math.floor(60 * Math.abs(totalAngle / Math.PI));
         numSamples = numSamples >= 2 ? numSamples : 2;
         return numSamples;
-    } 
+    };
 
     /**
      * Retrieves the coordinate info of the tree.

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -749,7 +749,6 @@ define([
      * @return {Array}
      */
     Empress.prototype.getCoords = function () {
-        var d = new Date();
         var tree = this._tree;
 
         // The coordinates (and colors) of the tree's nodes.
@@ -897,9 +896,6 @@ define([
                 addPoint(this.getX(node), this.getY(node));
             }
         }
-        var dt = new Date();
-        console.log("Circ time:", dt.getTime() - d.getTime());
-        console.log("coords length:", coords.length);
         return new Float32Array(coords);
     };
 

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -72,7 +72,7 @@ define([
          * @type {Array}
          * The default color of the tree
          */
-        this.DEFAULT_COLOR = [0, 0, 0];
+        this.DEFAULT_COLOR = [0.25, 0.25, 0.25];
 
         /**
          * @type {BPTree}

--- a/tests/test-circular-layout-computation.js
+++ b/tests/test-circular-layout-computation.js
@@ -226,8 +226,9 @@ require(["jquery", "BPTree", "BiomTable", "Empress"], function (
             ok(Math.abs(coords[30] - 2) < 1.0e-15); // start x arc position
             ok(Math.abs(coords[31 - 0]) < 1.0e-15); //start y arc position
             // prettier-ignore
-            ok(Math.abs(coords[175] - (-2)) < 1.0e-15); // end x arc position
-            ok(Math.abs(coords[176] - 0 < 1.0e-15)); // end y arc position
+            ok(Math.abs(coords[625] - (-2)) < 1.0e-15); // end x arc position
+            ok(Math.abs(coords[626] - 0 < 1.0e-15)); // end y arc position
+            console.log(coords);
         });
     });
 });

--- a/tests/test-empress.js
+++ b/tests/test-empress.js
@@ -795,11 +795,12 @@ require(["jquery", "UtilitiesForTesting", "util", "chroma"], function (
             sX = x * cos - y * sin;
             sY = x * Math.sin(langle - dangle) + y * Math.cos(langle - dangle);
 
-            // create 15 triangles to approximate sector
-            var deltaAngle = totalAngle / 15;
-            cos = Math.cos(deltaAngle);
-            sin = Math.sin(deltaAngle);
-            for (var line = 0; line < 15; line++) {
+            // create triangles to approximate sector
+            var numSamp = this.empress._numSampToApproximate(totalAngle);
+            var deltaAngle = totalAngle / numSamp;
+            cos = Math.cos(0);
+            sin = Math.sin(0);
+            for (var line = 0; line < numSamp; line++) {
                 // root of clade
                 exp.push(...[0, 1, 1, 1, 1]);
 


### PR DESCRIPTION
This PR dynamically adjusts the number of line segments used to draw branch arcs. The number of line segments used to draw an arc is determined by the following formula: `min(60 * (total angle of the arc / pi), 2)` This formula seems to work fairly well on the trees I have tested and also greatly reduced the size of the buffer. On one of the larger trees I tested, the buffer used to draw the tree went from having 39208150 elements to 9230430 elements which is a ~4x smaller!

I also changed the default branch color to a darker grey color after our discussion on Tuesday.