### PR TITLE
uncollapse by double click

### DIFF
--- a/empress/support_files/js/canvas-events.js
+++ b/empress/support_files/js/canvas-events.js
@@ -202,9 +202,23 @@ define(["glMatrix", "SelectedNodeMenu"], function (gl, SelectedNodeMenu) {
             }
         };
 
+        // uncollapses a clade if double clicked on
+        var doubleClick = function (e) {
+            var treeSpace = drawer.toTreeCoords(e.clientX, e.clientY);
+            var x = treeSpace.x;
+            var y = treeSpace.y;
+
+            var clade = empress.getRootNodeForPointInClade([x, y]);
+            if (clade === -1) {
+                return;
+            }
+            empress.dontCollapseClade(clade);
+        };
+
         canvas.onmousedown = mouseDown;
         canvas.onclick = mouseClick;
         canvas.onwheel = zoomTree;
+        canvas.ondblclick = doubleClick;
     };
 
     /**

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -313,6 +313,14 @@ define([
         this._collapsedClades = {};
 
         /**
+         * @type(Set)
+         * @private
+         * Clades that should will not be collapse. Currently, clades are only
+         * cleared from this set when resetTree() is called.
+         */
+        this._dontCollapse = new Set();
+
+        /**
          * @type{Array}
          * @private
          *
@@ -2134,6 +2142,7 @@ define([
             this.setNodeInfo(node, "visible", true);
         }
         this._collapsedClades = {};
+        this._dontCollapse = new Set();
         this._collapsedCladeBuffer = [];
         this._drawer.loadThickNodeBuff([]);
         this._drawer.loadCladeBuff([]);
@@ -2422,6 +2431,25 @@ define([
     };
 
     /**
+     * Adds clade to the "do not collapse list"
+     *
+     * @param{Number/String} clade The postorder position of a node (clade).
+     *                             This can either be an integer or a string.
+     */
+    Empress.prototype.dontCollapseClade = function (clade) {
+        this._dontCollapse.add(parseInt(clade));
+        this._collapsedClades = {};
+        // Note: currently collapseClades is the only method that set
+        // the node visibility property.
+        for (var i = 1; i <= this._tree.size; i++) {
+            this.setNodeInfo(i, "visible", true);
+        }
+
+        this._collapsedCladeBuffer = [];
+        this.collapseClades();
+        this.drawTree();
+    };
+    /**
      * Collapses all clades that share the same color into a quadrilateral.
      *
      * NOTE: Previously, this checked this._collapsedClades to see if there
@@ -2472,6 +2500,12 @@ define([
         var inorder = this._tree.inOrderNodes();
         for (var node in inorder) {
             node = inorder[node];
+
+            // dont collapse clade
+            if (this._dontCollapse.has(node)) {
+                console.log(node);
+                continue;
+            }
             var visible = this.getNodeInfo(node, "visible");
             var isTip = this._tree.isleaf(this._tree.postorderselect(node));
 

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -2437,7 +2437,9 @@ define([
      *                             This can either be an integer or a string.
      */
     Empress.prototype.dontCollapseClade = function (clade) {
-        this._dontCollapse.add(parseInt(clade));
+        var scope = this;
+        var nodes = this.getCladeNodes(parseInt(clade));
+        nodes.forEach(function(node) {scope._dontCollapse.add(node)})
         this._collapsedClades = {};
         // Note: currently collapseClades is the only method that set
         // the node visibility property.

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -2439,7 +2439,9 @@ define([
     Empress.prototype.dontCollapseClade = function (clade) {
         var scope = this;
         var nodes = this.getCladeNodes(parseInt(clade));
-        nodes.forEach(function(node) {scope._dontCollapse.add(node)})
+        nodes.forEach(function (node) {
+            scope._dontCollapse.add(node);
+        });
         this._collapsedClades = {};
         // Note: currently collapseClades is the only method that set
         // the node visibility property.

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -2503,7 +2503,6 @@ define([
 
             // dont collapse clade
             if (this._dontCollapse.has(node)) {
-                console.log(node);
                 continue;
             }
             var visible = this.getNodeInfo(node, "visible");


### PR DESCRIPTION
Crude method to uncollapse clades by double clicking on them. The main goal of this pr was to allow users to uncollapse clades so that figure 2a can be recreated. This PR does NOT support the ability to recollapse the clade. The only way to recollapse is by toggling the "collapse clade" check box. However, this pr does set up the basic frame work and can be extended to support more complex operations.