### PR TITLE
ENH: Enlarge selected samples in Emperor

### DIFF
--- a/empress/support_files/js/emperor-callbacks.js
+++ b/empress/support_files/js/emperor-callbacks.js
@@ -5,18 +5,18 @@
  */
 
 empress.setOnNodeMenuVisibleCallback(function (samples) {
-    // reset emissive settings for all markers
-    ec.decViews.scatter.setEmissive(0x000000);
+    // reset scale settings for all samples
+    ec.decViews.scatter.setScale(1);
 
     // retrieve the plotting objects
     samples = ec.decModels.models.scatter.getPlottableByIDs(samples);
-    ec.decViews.scatter.setEmissive(0x8c8c8f, samples);
+    ec.decViews.scatter.setScale(2, samples);
     ec.sceneViews[0].needsUpdate = true;
 });
 
 empress.setOnNodeMenuHiddenCallback(function (samples) {
     samples = ec.decModels.models.scatter.getPlottableByIDs(samples);
-    ec.decViews.scatter.setEmissive(0x000000, samples);
+    ec.decViews.scatter.setScale(1, samples);
     ec.sceneViews[0].needsUpdate = true;
 });
 
@@ -171,6 +171,7 @@ ec.controllers.color.addEventListener("value-double-clicked", function (
     // reset emissive settings for all markers since an ongoing timer may have
     // been cancelled
     ec.decViews.scatter.setEmissive(0x000000);
+    ec.decViews.scatter.setScale(1);
     plotView.needsUpdate = true;
 
     // if there's any coloring setup remove it, and re-enable the update button

--- a/empress/support_files/js/emperor-callbacks.js
+++ b/empress/support_files/js/emperor-callbacks.js
@@ -10,10 +10,9 @@ empress.setOnNodeMenuVisibleCallback(function (samples) {
 
     // retrieve the plotting objects
     samples = ec.decModels.models.scatter.getPlottableByIDs(samples);
-    if(ec.UIState['view.usesPointCloud']) {
+    if (ec.UIState["view.usesPointCloud"]) {
         ec.decViews.scatter.setScale(10, samples);
-    }
-    else {
+    } else {
         ec.decViews.scatter.setScale(2, samples);
     }
     ec.sceneViews[0].needsUpdate = true;

--- a/empress/support_files/js/emperor-callbacks.js
+++ b/empress/support_files/js/emperor-callbacks.js
@@ -10,7 +10,12 @@ empress.setOnNodeMenuVisibleCallback(function (samples) {
 
     // retrieve the plotting objects
     samples = ec.decModels.models.scatter.getPlottableByIDs(samples);
-    ec.decViews.scatter.setScale(2, samples);
+    if(ec.UIState['view.usesPointCloud']) {
+        ec.decViews.scatter.setScale(10, samples);
+    }
+    else {
+        ec.decViews.scatter.setScale(2, samples);
+    }
     ec.sceneViews[0].needsUpdate = true;
 });
 

--- a/empress/support_files/js/emperor-callbacks.js
+++ b/empress/support_files/js/emperor-callbacks.js
@@ -171,7 +171,6 @@ ec.controllers.color.addEventListener("value-double-clicked", function (
     // reset emissive settings for all markers since an ongoing timer may have
     // been cancelled
     ec.decViews.scatter.setEmissive(0x000000);
-    ec.decViews.scatter.setScale(1);
     plotView.needsUpdate = true;
 
     // if there's any coloring setup remove it, and re-enable the update button


### PR DESCRIPTION
Closes #373. Ideally we'd have options for choosing how to visually represent selected samples, but I think enlarging is a more robust solution than the emissive stuff.

Emissives are still used for representing samples selected in Emperor using the dragging options -- the scaling stuff is only used for representing samples that contain a given selected node/nodes in Empress. I think having these things be split up looks nice, personally.

There are still the Emperor scale controls available, which would mess with things here (allowing for all sorts of interaction bugs -- e.g. the user re-scales the samples or something in Emperor only for that re-scaling to get lost when the user selects/unselects nodes in Empress), but honestly we could just hide that part of the Emperor menu and I think that'd be good enough for now...?

![fancy](https://user-images.githubusercontent.com/4177727/95253755-b6205c00-07d3-11eb-9a68-d3fd42f013a9.gif)
