### PR TITLE
NEW Add reverse argument for Colorer

### DIFF
--- a/empress/support_files/js/animation-panel-handler.js
+++ b/empress/support_files/js/animation-panel-handler.js
@@ -16,6 +16,9 @@ define(["Colorer", "util"], function (Colorer, util) {
 
         // animation GUI components
         this.colorSelect = document.getElementById("animate-color-select");
+        this.reverseColorChk = document.getElementById(
+            "animate-color-reverse-chk"
+        );
         this.gradient = document.getElementById("animate-gradient");
         this.trajectory = document.getElementById("animate-trajectory");
         this.collapseChk = document.getElementById("animate-collapse-chk");
@@ -109,6 +112,7 @@ define(["Colorer", "util"], function (Colorer, util) {
      */
     AnimationPanel.prototype._toggleSelects = function (disableStatus) {
         this.colorSelect.disabled = disableStatus;
+        this.reverseColorChk.disabled = disableStatus;
         this.gradient.disabled = disableStatus;
         this.trajectory.disabled = disableStatus;
     };
@@ -123,6 +127,7 @@ define(["Colorer", "util"], function (Colorer, util) {
     AnimationPanel.prototype.setEnabled = function (enabled) {
         var isDisabled = !enabled;
         this.colorSelect.disabled = isDisabled;
+        this.reverseColorChk.disabled = isDisabled;
         this.gradient.disabled = isDisabled;
         this.trajectory.disabled = isDisabled;
 
@@ -221,6 +226,7 @@ define(["Colorer", "util"], function (Colorer, util) {
             var gradient = scope.gradient.value;
             var trajectory = scope.trajectory.value;
             var cm = scope.colorSelect.value;
+            var reverse = scope.reverseColorChk.checked;
             var collapse = scope.collapseChk.checked;
             var lWidth = scope.lWidth.value;
 
@@ -230,7 +236,8 @@ define(["Colorer", "util"], function (Colorer, util) {
                 gradient,
                 cm,
                 collapse,
-                lWidth
+                lWidth,
+                reverse
             );
 
             // start animation

--- a/empress/support_files/js/animator.js
+++ b/empress/support_files/js/animator.js
@@ -120,13 +120,17 @@ define(["Colorer", "util"], function (Colorer, util) {
      * @param {Boolean} collapse Tells animator to collapse clades
      * @param {Number} lWidth Tells animator how thick to make colored tree
      *                        branches
+     * @param{Boolean} reverse Defaults to false. If true, the color scale
+     *                         will be reversed, with respect to its default
+     *                         orientation.
      */
     Animator.prototype.setAnimationParameters = function (
         trajectory,
         gradient,
         cm,
         collapse,
-        lWidth
+        lWidth,
+        reverse = false
     ) {
         this.gradientCol = gradient;
         this.gradientSteps = this.empress.getUniqueSampleValues(gradient);
@@ -140,7 +144,13 @@ define(["Colorer", "util"], function (Colorer, util) {
         this.trajectoryCol = trajectory;
         var trajectories = this.empress.getUniqueSampleValues(trajectory);
         // Assign a color to each unique category
-        var colorer = new Colorer(cm, trajectories);
+        var colorer = new Colorer(
+            cm,
+            trajectories,
+            undefined,
+            undefined,
+            reverse
+        );
         this.cm = colorer.getMapRGB();
         this.legendInfo = colorer.getMapHex();
 

--- a/empress/support_files/js/barplot-layer.js
+++ b/empress/support_files/js/barplot-layer.js
@@ -355,7 +355,7 @@ define([
         // feature metadata field for coloring is the first in the selector)
         this.colorByFMField = chgColorFMFieldSelector.value;
         this.colorByFMColorMap = colormapSelector.value;
-        this.reverseFMColorMap = reverseColormapCheckbox.checked;
+        this.colorByFMColorReverse = reverseColormapCheckbox.checked;
         // Alter visibility of the color-changing details when the "Color
         // by..." checkbox is clicked
         $(chgColorCheckbox).change(function () {
@@ -365,7 +365,7 @@ define([
                 scope.colorByFM = true;
                 scope.colorByFMField = chgColorFMFieldSelector.value;
                 scope.colorByFMColorMap = colormapSelector.value;
-                scope.reverseFMColorMap = reverseColormapCheckbox.checked;
+                scope.colorByFMColorReverse = reverseColormapCheckbox.checked;
                 scope.colorByFMContinuous = continuousValCheckbox.checked;
                 // Hide the default color row (since default colors
                 // aren't used when f.m. coloring is enabled)

--- a/empress/support_files/js/barplot-layer.js
+++ b/empress/support_files/js/barplot-layer.js
@@ -94,6 +94,7 @@ define([
         this.colorByFM = false;
         this.colorByFMField = null;
         this.colorByFMColorMap = null;
+        this.colorByFMColorReverse = false;
         this.colorByFMContinuous = false;
         this.colorByFMColorMapDiscrete = true;
         this.defaultLength = BarplotLayer.DEFAULT_LENGTH;
@@ -310,6 +311,24 @@ define([
             "barplot-layer-" + this.uniqueNum + "-fm-colormap";
         colormapLbl.setAttribute("for", colormapSelector.id);
 
+        // Add a row for choosing whether the color scale should
+        // be reversed
+        var reverseColormapP = colorDetailsDiv.appendChild(
+            document.createElement("p")
+        );
+        var reverseColormapLbl = reverseColormapP.appendChild(
+            document.createElement("label")
+        );
+        reverseColormapLbl.innerText = "Reverse Color Map";
+        var reverseColormapCheckbox = reverseColormapP.appendChild(
+            document.createElement("input")
+        );
+        reverseColormapCheckbox.id =
+            "barplot-layer-" + this.uniqueNum + "-fmcolor-reverse-chk";
+        reverseColormapCheckbox.setAttribute("type", "checkbox");
+        reverseColormapCheckbox.classList.add("empress-input");
+        reverseColormapLbl.setAttribute("for", reverseColormapCheckbox.id);
+
         // Add a row for choosing the scale type (i.e. whether to use
         // continuous coloring or not)
         // This mimics Emperor's "Continuous values" checkbox
@@ -336,6 +355,7 @@ define([
         // feature metadata field for coloring is the first in the selector)
         this.colorByFMField = chgColorFMFieldSelector.value;
         this.colorByFMColorMap = colormapSelector.value;
+        this.reverseFMColorMap = reverseColormapCheckbox.checked;
         // Alter visibility of the color-changing details when the "Color
         // by..." checkbox is clicked
         $(chgColorCheckbox).change(function () {
@@ -345,6 +365,7 @@ define([
                 scope.colorByFM = true;
                 scope.colorByFMField = chgColorFMFieldSelector.value;
                 scope.colorByFMColorMap = colormapSelector.value;
+                scope.reverseFMColorMap = reverseColormapCheckbox.checked;
                 scope.colorByFMContinuous = continuousValCheckbox.checked;
                 // Hide the default color row (since default colors
                 // aren't used when f.m. coloring is enabled)

--- a/empress/support_files/js/barplot-layer.js
+++ b/empress/support_files/js/barplot-layer.js
@@ -398,6 +398,9 @@ define([
                 scope.colorByFMColorMapDiscrete = false;
             }
         });
+        $(reverseColormapCheckbox).change(function () {
+            scope.colorByFMColorReverse = reverseColormapCheckbox.checked;
+        });
         $(continuousValCheckbox).change(function () {
             scope.colorByFMContinuous = continuousValCheckbox.checked;
         });

--- a/empress/support_files/js/barplot-layer.js
+++ b/empress/support_files/js/barplot-layer.js
@@ -106,6 +106,7 @@ define([
         // Various properties of the barplot layer state for sample metadata
         this.colorBySMField = null;
         this.colorBySMColorMap = null;
+        this.colorBySMColorReverse = false;
         this.lengthSM = BarplotLayer.DEFAULT_LENGTH;
 
         // Initialize the HTML elements of this barplot layer
@@ -575,6 +576,24 @@ define([
             "barplot-layer-" + this.uniqueNum + "-sm-colormap";
         colormapLbl.setAttribute("for", colormapSelector.id);
 
+        // Add a row for choosing whether the color scale should
+        // be reversed
+        var reverseColormapP = this.smDiv.appendChild(
+            document.createElement("p")
+        );
+        var reverseColormapLbl = reverseColormapP.appendChild(
+            document.createElement("label")
+        );
+        reverseColormapLbl.innerText = "Reverse Color Map";
+        var reverseColormapCheckbox = reverseColormapP.appendChild(
+            document.createElement("input")
+        );
+        reverseColormapCheckbox.id =
+            "barplot-layer-" + this.uniqueNum + "-smcolor-reverse-chk";
+        reverseColormapCheckbox.setAttribute("type", "checkbox");
+        reverseColormapCheckbox.classList.add("empress-input");
+        reverseColormapLbl.setAttribute("for", reverseColormapCheckbox.id);
+
         var lenP = this.smDiv.appendChild(document.createElement("p"));
         var lenLbl = lenP.appendChild(document.createElement("label"));
         lenLbl.innerText = "Length";
@@ -589,11 +608,15 @@ define([
         // TODO initialize defaults more sanely
         this.colorBySMField = chgFieldSMFieldSelector.value;
         this.colorBySMColorMap = colormapSelector.value;
+        this.colorBySMColorReverse = reverseColormapCheckbox.checked;
         $(chgFieldSMFieldSelector).change(function () {
             scope.colorBySMField = chgFieldSMFieldSelector.value;
         });
         $(colormapSelector).change(function () {
             scope.colorBySMColorMap = colormapSelector.value;
+        });
+        $(reverseColormapCheckbox).change(function () {
+            scope.colorBySMColorReverse = reverseColormapCheckbox.checked;
         });
         $(lenInput).change(function () {
             scope.lengthSM = util.parseAndValidateNum(

--- a/empress/support_files/js/colorer.js
+++ b/empress/support_files/js/colorer.js
@@ -124,7 +124,7 @@ define(["chroma", "underscore", "util"], function (chroma, _, util) {
             palette = chroma.brewer[this.color];
         }
         if (this.reverse) {
-            palette = _.toArray(palette);
+            palette = _.clone(palette);
             palette.reverse();
         }
         for (var i = 0; i < this.sortedUniqueValues.length; i++) {

--- a/empress/support_files/js/colorer.js
+++ b/empress/support_files/js/colorer.js
@@ -224,7 +224,6 @@ define(["chroma", "underscore", "util"], function (chroma, _, util) {
         } else {
             domain = [min, max];
         }
-        console.log("domain: ", domain);
         var interpolator = chroma.scale(this.color).domain(domain);
         _.each(split.numeric, function (n) {
             scope.__valueToColor[n] = interpolator(parseFloat(n));

--- a/empress/support_files/js/colorer.js
+++ b/empress/support_files/js/colorer.js
@@ -123,17 +123,13 @@ define(["chroma", "underscore", "util"], function (chroma, _, util) {
         } else {
             palette = chroma.brewer[this.color];
         }
-        const n_unique = this.sortedUniqueValues.length;
-        var colorIndex;
-        for (var i = 0; i < n_unique; i++) {
-            if (this.reverse) {
-                colorIndex = n_unique - i - 1;
-            } else {
-                colorIndex = i;
-            }
+        if (this.reverse) {
+            palette = [...palette];
+            palette.reverse();
+        }
+        for (var i = 0; i < this.sortedUniqueValues.length; i++) {
             var modIndex = i % palette.length;
-            this.__valueToColor[this.sortedUniqueValues[colorIndex]] =
-                palette[modIndex];
+            this.__valueToColor[this.sortedUniqueValues[i]] = palette[modIndex];
         }
     };
 

--- a/empress/support_files/js/colorer.js
+++ b/empress/support_files/js/colorer.js
@@ -124,7 +124,7 @@ define(["chroma", "underscore", "util"], function (chroma, _, util) {
             palette = chroma.brewer[this.color];
         }
         if (this.reverse) {
-            palette = [...palette];
+            palette = _.toArray(palette);
             palette.reverse();
         }
         for (var i = 0; i < this.sortedUniqueValues.length; i++) {

--- a/empress/support_files/js/colorer.js
+++ b/empress/support_files/js/colorer.js
@@ -160,7 +160,12 @@ define(["chroma", "underscore", "util"], function (chroma, _, util) {
             // If there's only 1 unique value, set its color as the first in
             // the color map. This matches the behavior of Emperor.
             var onlyVal = this.sortedUniqueValues[0];
-            this.__valueToColor[onlyVal] = chroma.brewer[this.color][0];
+            var brewer = chroma.brewer[this.color];
+            if (this.reverse) {
+                this.__valueToColor[onlyVal] = brewer[brewer.length - 1];
+            } else {
+                this.__valueToColor[onlyVal] = brewer[0];
+            }
         } else {
             // ... Otherwise, do normal interpolation -- the first value gets
             // the "first" color in the color map, the last value gets the

--- a/empress/support_files/js/colorer.js
+++ b/empress/support_files/js/colorer.js
@@ -28,6 +28,9 @@ define(["chroma", "underscore", "util"], function (chroma, _, util) {
      *                                 color map is discrete and/or
      *                                 useQuantScale is false, then this will
      *                                 be ignored.)
+     * @param{Boolean} reverse Defaults to false. If true, the color scale
+     *                         will be reversed, with respect to its default
+     *                         orientation.
      * @return{Colorer}
      * constructs Colorer
      */
@@ -35,7 +38,8 @@ define(["chroma", "underscore", "util"], function (chroma, _, util) {
         color,
         values,
         useQuantScale = false,
-        gradientIDSuffix = 0
+        gradientIDSuffix = 0,
+        reverse = false
     ) {
         var scope = this;
 
@@ -43,6 +47,7 @@ define(["chroma", "underscore", "util"], function (chroma, _, util) {
         this.sortedUniqueValues = util.naturalSort(_.uniq(values));
 
         this.color = color;
+        this.reverse = reverse;
 
         // This object will describe a mapping of unique field values to colors
         this.__valueToColor = {};
@@ -118,9 +123,17 @@ define(["chroma", "underscore", "util"], function (chroma, _, util) {
         } else {
             palette = chroma.brewer[this.color];
         }
-        for (var i = 0; i < this.sortedUniqueValues.length; i++) {
+        const n_unique = this.sortedUniqueValues.length;
+        var colorIndex;
+        for (var i = 0; i < n_unique; i++) {
+            if (this.reverse) {
+                colorIndex = n_unique - i - 1;
+            } else {
+                colorIndex = i;
+            }
             var modIndex = i % palette.length;
-            this.__valueToColor[this.sortedUniqueValues[i]] = palette[modIndex];
+            this.__valueToColor[this.sortedUniqueValues[colorIndex]] =
+                palette[modIndex];
         }
     };
 
@@ -157,9 +170,14 @@ define(["chroma", "underscore", "util"], function (chroma, _, util) {
             // the "first" color in the color map, the last value gets the
             // "last" color in the color map, and things in between are
             // interpolated. Chroma takes care of all of the hard work.
-            var interpolator = chroma
-                .scale(this.color)
-                .domain([0, this.sortedUniqueValues.length - 1]);
+            var domain;
+            var rangeMax = this.sortedUniqueValues.length - 1;
+            if (this.reverse) {
+                domain = [rangeMax, 0];
+            } else {
+                domain = [0, rangeMax];
+            }
+            var interpolator = chroma.scale(this.color).domain(domain);
 
             for (var i = 0; i < this.sortedUniqueValues.length; i++) {
                 var val = this.sortedUniqueValues[i];
@@ -200,7 +218,14 @@ define(["chroma", "underscore", "util"], function (chroma, _, util) {
         var nums = _.map(split.numeric, parseFloat);
         var min = _.min(nums);
         var max = _.max(nums);
-        var interpolator = chroma.scale(this.color).domain([min, max]);
+        var domain;
+        if (this.reverse) {
+            domain = [max, min];
+        } else {
+            domain = [min, max];
+        }
+        console.log("domain: ", domain);
+        var interpolator = chroma.scale(this.color).domain(domain);
         _.each(split.numeric, function (n) {
             scope.__valueToColor[n] = interpolator(parseFloat(n));
         });

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -1983,10 +1983,18 @@ define([
      *                        internal node feature metadata without doing any
      *                        propagation. If this is anything else, this will
      *                        throw an error.
+     * @param{Boolean} reverse Defaults to false. If true, the color scale
+     *                         will be reversed, with respect to its default
+     *                         orientation.
      *
      * @return {Object} Maps unique values in this f. metadata column to colors
      */
-    Empress.prototype.colorByFeatureMetadata = function (cat, color, method) {
+    Empress.prototype.colorByFeatureMetadata = function (
+        cat,
+        color,
+        method,
+        reverse = false
+    ) {
         var fmInfo = this.getUniqueFeatureMetadataInfo(cat, method);
         var sortedUniqueValues = fmInfo.sortedUniqueValues;
         var uniqueValueToFeatures = fmInfo.uniqueValueToFeatures;
@@ -2000,7 +2008,13 @@ define([
         });
 
         // assign colors to unique values
-        var colorer = new Colorer(color, sortedUniqueValues);
+        var colorer = new Colorer(
+            color,
+            sortedUniqueValues,
+            undefined,
+            undefined,
+            reverse
+        );
         // colors for drawing the tree
         var cm = colorer.getMapRGB();
         // colors for the legend

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -1848,19 +1848,28 @@ define([
      *
      * @param {String} cat Sample metadata category to use
      * @param {String} color Color map to use
+     * @param{Boolean} reverse Defaults to false. If true, the color scale
+     *                         will be reversed, with respect to its default
+     *                         orientation.
      *
      * @return {Object} If there exists at least one group with unique features
      *                  then an object will be returned that maps groups with
      *                  unique features to a color. If there doesn't exist a
      *                  group with unique features then null will be returned.
      */
-    Empress.prototype.colorBySampleCat = function (cat, color) {
+    Empress.prototype.colorBySampleCat = function (cat, color, reverse = true) {
         var tree = this._tree;
         var obs = this._biom.getObsBy(cat);
         var categories = Object.keys(obs);
 
         // Assign colors to categories
-        var colorer = new Colorer(color, categories);
+        var colorer = new Colorer(
+            color,
+            categories,
+            undefined,
+            undefined,
+            reverse
+        );
         // colors for drawing the tree
         var cm = colorer.getMapRGB();
         // colors for the legend

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -1587,7 +1587,8 @@ define([
                     layer.colorByFMColorMap,
                     sortedUniqueColorValues,
                     layer.colorByFMContinuous,
-                    layer.uniqueNum
+                    layer.uniqueNum,
+                    layer.colorByFMColorReverse
                 );
             } catch (err) {
                 // If the Colorer construction failed (should only have

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -1864,7 +1864,11 @@ define([
      *                  unique features to a color. If there doesn't exist a
      *                  group with unique features then null will be returned.
      */
-    Empress.prototype.colorBySampleCat = function (cat, color, reverse = false) {
+    Empress.prototype.colorBySampleCat = function (
+        cat,
+        color,
+        reverse = false
+    ) {
         var tree = this._tree;
         var obs = this._biom.getObsBy(cat);
         var categories = Object.keys(obs);

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -1855,7 +1855,7 @@ define([
      *
      * @param {String} cat Sample metadata category to use
      * @param {String} color Color map to use
-     * @param{Boolean} reverse Defaults to false. If true, the color scale
+     * @param {Boolean} reverse Defaults to false. If true, the color scale
      *                         will be reversed, with respect to its default
      *                         orientation.
      *

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -1394,7 +1394,13 @@ define([
         var sortedUniqueValues = this.getUniqueSampleValues(
             layer.colorBySMField
         );
-        var colorer = new Colorer(layer.colorBySMColorMap, sortedUniqueValues);
+        var colorer = new Colorer(
+            layer.colorBySMColorMap,
+            sortedUniqueValues,
+            undefined,
+            undefined,
+            layer.colorBySMColorReverse
+        );
         var sm2color = colorer.getMapRGB();
         // Do most of the hard work: compute the frequencies for each tip (only
         // the tips present in the BIOM table, that is)

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -1864,7 +1864,7 @@ define([
      *                  unique features to a color. If there doesn't exist a
      *                  group with unique features then null will be returned.
      */
-    Empress.prototype.colorBySampleCat = function (cat, color, reverse = true) {
+    Empress.prototype.colorBySampleCat = function (cat, color, reverse = false) {
         var tree = this._tree;
         var obs = this._biom.getObsBy(cat);
         var categories = Object.keys(obs);

--- a/empress/support_files/js/side-panel-handler.js
+++ b/empress/support_files/js/side-panel-handler.js
@@ -64,6 +64,9 @@ define(["underscore", "Colorer", "util"], function (_, Colorer, util) {
         this.fSel = document.getElementById("feature-options");
         this.fAddOpts = document.getElementById("feature-add");
         this.fColor = document.getElementById("feature-color");
+        this.fReverseColor = document.getElementById(
+            "feature-reverse-color-chk"
+        );
         this.fCollapseCladesChk = document.getElementById(
             "feature-collapse-chk"
         );
@@ -183,6 +186,7 @@ define(["underscore", "Colorer", "util"], function (_, Colorer, util) {
                 fChk: { checked: false },
                 fSel: { disabled: true },
                 fColor: { value: "discrete-coloring-qiime" },
+                fReverseColor: { checked: false },
                 fLineWidth: { value: 0 },
                 fMethodChk: { checked: true },
                 fCollapseCladesChk: { checked: false },
@@ -268,7 +272,13 @@ define(["underscore", "Colorer", "util"], function (_, Colorer, util) {
         var colBy = this.fSel.value;
         var col = this.fColor.value;
         var coloringMethod = this.fMethodChk.checked ? "tip" : "all";
-        this.empress.colorByFeatureMetadata(colBy, col, coloringMethod);
+        var reverse = this.fReverseColor.checked;
+        this.empress.colorByFeatureMetadata(
+            colBy,
+            col,
+            coloringMethod,
+            reverse
+        );
     };
 
     /**
@@ -540,6 +550,7 @@ define(["underscore", "Colorer", "util"], function (_, Colorer, util) {
         };
         this.fSel.onchange = showUpdateBtn;
         this.fColor.onchange = showUpdateBtn;
+        this.fReverseColor.onchange = showUpdateBtn;
         this.fLineWidth.onchange = showUpdateBtn;
         this.fMethodChk.onchange = function () {
             scope.updateFeatureMethodDesc();

--- a/empress/support_files/js/side-panel-handler.js
+++ b/empress/support_files/js/side-panel-handler.js
@@ -53,6 +53,9 @@ define(["underscore", "Colorer", "util"], function (_, Colorer, util) {
         this.sSel = document.getElementById("sample-options");
         this.sAddOpts = document.getElementById("sample-add");
         this.sColor = document.getElementById("sample-color");
+        this.sReverseColor = document.getElementById(
+            "sample-reverse-color-chk"
+        );
         this.sCollapseCladesChk = document.getElementById(
             "sample-collapse-chk"
         );
@@ -172,6 +175,7 @@ define(["underscore", "Colorer", "util"], function (_, Colorer, util) {
                 sChk: { checked: false },
                 sSel: { disabled: true },
                 sColor: { value: "discrete-coloring-qiime" },
+                sReverseColor: { checked: false },
                 sLineWidth: { value: 0 },
                 sCollapseCladesChk: { checked: false },
             },
@@ -460,6 +464,7 @@ define(["underscore", "Colorer", "util"], function (_, Colorer, util) {
         };
         this.sSel.onchange = showUpdateBtn;
         this.sColor.onchange = showUpdateBtn;
+        this.sReverseColor.onchange = showUpdateBtn;
         this.sLineWidth.onchange = showUpdateBtn;
 
         this.sUpdateBtn.onclick = function () {

--- a/empress/support_files/js/side-panel-handler.js
+++ b/empress/support_files/js/side-panel-handler.js
@@ -259,7 +259,8 @@ define(["underscore", "Colorer", "util"], function (_, Colorer, util) {
     SidePanel.prototype._colorSampleTree = function () {
         var colBy = this.sSel.value;
         var col = this.sColor.value;
-        var keyInfo = this.empress.colorBySampleCat(colBy, col);
+        var reverse = this.sReverseColor.checked;
+        var keyInfo = this.empress.colorBySampleCat(colBy, col, reverse);
         if (keyInfo === null) {
             util.toastMsg(
                 "No unique branches found for this metadata category"

--- a/empress/support_files/templates/side-panel.html
+++ b/empress/support_files/templates/side-panel.html
@@ -34,6 +34,11 @@
         </label>
       </p>
       <p>
+        <label for="sample-reverse-color-chk">Reverse Color Map</label>
+        <input id="sample-reverse-color-chk" type="checkbox" value="false"
+               class="empress-input">
+      </p>
+      <p>
         <label for="sample-collapse-chk">Collapse Clades</label>
         <input id="sample-collapse-chk" type="checkbox" value="false"
                class="empress-input">

--- a/empress/support_files/templates/side-panel.html
+++ b/empress/support_files/templates/side-panel.html
@@ -235,6 +235,11 @@
     </label>
   </p>
   <p>
+    <label for="animate-color-reverse-chk">Reverse Color Map</label>
+    <input id="animate-color-reverse-chk" type="checkbox" value="false"
+           class="empress-input">
+  </p>
+  <p>
     <label for="animate-gradient">Gradient</label>
     <label class="select-container">
       <select id="animate-gradient"></select>

--- a/empress/support_files/templates/side-panel.html
+++ b/empress/support_files/templates/side-panel.html
@@ -77,6 +77,11 @@
           <select id="feature-color"></select>
         </label>
       </p>
+    <p>
+      <label for="feature-reverse-color-chk">Reverse Color Map</label>
+      <input id="feature-reverse-color-chk" type="checkbox" value="false"
+             class="empress-input">
+    </p>
       <p>
         <label for="feature-collapse-chk">Collapse Clades</label>
         <input id="feature-collapse-chk" type="checkbox" value="false"

--- a/tests/test-animation-panel-handler.js
+++ b/tests/test-animation-panel-handler.js
@@ -29,6 +29,10 @@ require([
             colorSelect.setAttribute("id", "animate-color-select");
             this.div.appendChild(colorSelect);
 
+            var reverseColorChk = document.createElement("checkbox");
+            reverseColorChk.setAttribute("id", "animate-color-reverse-chk");
+            this.div.appendChild(reverseColorChk);
+
             var gradient = document.createElement("select");
             gradient.setAttribute("id", "animate-gradient");
             this.div.appendChild(gradient);
@@ -149,6 +153,7 @@ require([
 
     test("setEnabled", function () {
         notOk(this.panel.colorSelect.disabled);
+        notOk(this.panel.reverseColorChk.disabled);
         notOk(this.panel.gradient.disabled);
         notOk(this.panel.trajectory.disabled);
 
@@ -165,6 +170,7 @@ require([
         this.panel.setEnabled(true);
 
         notOk(this.panel.colorSelect.disabled);
+        notOk(this.panel.reverseColorChk.disabled);
         notOk(this.panel.gradient.disabled);
         notOk(this.panel.trajectory.disabled);
 
@@ -181,6 +187,7 @@ require([
         this.panel.setEnabled(false);
 
         ok(this.panel.colorSelect.disabled);
+        ok(this.panel.reverseColorChk.disabled);
         ok(this.panel.gradient.disabled);
         ok(this.panel.trajectory.disabled);
 
@@ -292,6 +299,7 @@ require([
     test("_toggleSelects, true", function () {
         this.panel._toggleSelects(true);
         ok(this.panel.colorSelect.disabled);
+        ok(this.panel.reverseColorChk.disabled);
         ok(this.panel.gradient.disabled);
         ok(this.panel.trajectory.disabled);
     });
@@ -299,6 +307,7 @@ require([
     test("_toggleSelects, false", function () {
         this.panel._toggleSelects(false);
         ok(!this.panel.colorSelect.disabled);
+        ok(!this.panel.reverseColorChk.disabled);
         ok(!this.panel.gradient.disabled);
         ok(!this.panel.trajectory.disabled);
     });

--- a/tests/test-barplots.js
+++ b/tests/test-barplots.js
@@ -311,6 +311,7 @@ require([
         // Check sample metadata barplot defaults
         equal(layer1.colorBySMField, empress._barplotPanel.smCols[0]);
         equal(layer1.colorBySMColorMap, "discrete-coloring-qiime");
+        equal(layer1.colorBySMColorReverse, false);
         equal(layer1.lengthSM, BarplotLayer.DEFAULT_LENGTH);
     });
     // TODO: Test that interacting with various elements of the BarplotLayer UI

--- a/tests/test-barplots.js
+++ b/tests/test-barplots.js
@@ -298,7 +298,7 @@ require([
         notOk(layer1.colorByFM);
         equal(layer1.colorByFMField, empress._barplotPanel.fmCols[0]);
         equal(layer1.colorByFMColorMap, "discrete-coloring-qiime");
-        equal(layer1.colorByFMColorReverse, false);
+        notOk(layer1.colorByFMColorReverse);
         notOk(layer1.colorByFMContinuous);
         ok(layer1.colorByFMColorMapDiscrete);
 
@@ -311,7 +311,7 @@ require([
         // Check sample metadata barplot defaults
         equal(layer1.colorBySMField, empress._barplotPanel.smCols[0]);
         equal(layer1.colorBySMColorMap, "discrete-coloring-qiime");
-        equal(layer1.colorBySMColorReverse, false);
+        notOk(layer1.colorBySMColorReverse);
         equal(layer1.lengthSM, BarplotLayer.DEFAULT_LENGTH);
     });
     // TODO: Test that interacting with various elements of the BarplotLayer UI

--- a/tests/test-barplots.js
+++ b/tests/test-barplots.js
@@ -298,6 +298,7 @@ require([
         notOk(layer1.colorByFM);
         equal(layer1.colorByFMField, empress._barplotPanel.fmCols[0]);
         equal(layer1.colorByFMColorMap, "discrete-coloring-qiime");
+        equal(layer1.colorByFMColorReverse, false);
         notOk(layer1.colorByFMContinuous);
         ok(layer1.colorByFMColorMapDiscrete);
 

--- a/tests/test-colorer.js
+++ b/tests/test-colorer.js
@@ -306,6 +306,26 @@ require([
             equal(_.keys(hexmap)[0], "abc");
             equal(hexmap.abc, "#440154");
         });
+        test("Test using a sequential color map and a single value and reverse = true", function () {
+            var colorer = new Colorer(
+                "Viridis",
+                ["abc"],
+                undefined,
+                undefined,
+                true
+            );
+            // The last value in the color map (for viridis, dark purple)
+            // should be used.
+            equal(colorer.__valueToColor.abc, "#fee825");
+
+            rgbmap = colorer.getMapRGB();
+            equal(_.keys(rgbmap).length, 1);
+            equal(_.keys(rgbmap)[0], "abc");
+            hexmap = colorer.getMapHex();
+            equal(_.keys(hexmap).length, 1);
+            equal(_.keys(hexmap)[0], "abc");
+            equal(hexmap.abc, "#fee825");
+        });
         test("Test that using a sequential / diverging color map with useQuantScale = true throws an error when there are < 2 unique numeric values", function () {
             throws(function () {
                 new Colorer("RdBu", ["abc"], true);

--- a/tests/test-colorer.js
+++ b/tests/test-colorer.js
@@ -145,8 +145,10 @@ require([
             var eles = ["5", "2", "3", "1", "4", "0", "-5"];
             var colorer = new Colorer("PiYG", eles, true);
 
-            // Expected colors determined by reversing
-            // the colors in the previous test
+            // Expected colors determined by trying
+            // chroma.scale("PiYG").domain([-5,5])(n); where n = 0, 1, 2, etc.
+            // (see the interactive docs at https://gka.github.io/chroma.js/ --
+            // super useful for testing this)
 
             // Test extreme numeric values
             equal(colorer.__valueToColor["-5"], "#8e0152");
@@ -328,7 +330,6 @@ require([
             equal(hexmap["100"], "#33a02c");
         });
         test("Test discrete color map with reverse = true", function () {
-            // CVALDISCRETETEST
             var colorer = new Colorer(
                 "discrete-coloring-qiime",
                 ["1", "2", "100", "abc"],

--- a/tests/test-colorer.js
+++ b/tests/test-colorer.js
@@ -330,7 +330,7 @@ require([
         test("Test discrete color map with reverse = true", function () {
             // CVALDISCRETETEST
             var colorer = new Colorer(
-                "Paired",
+                "discrete-coloring-qiime",
                 ["1", "2", "100", "abc"],
                 false,
                 undefined,
@@ -340,10 +340,10 @@ require([
             equal(_.keys(hexmap).length, 4);
             // Note that although "abc" is non-numeric it still gets assigned a
             // (normal) color
-            equal(hexmap["100"], "#a6cee3");
-            equal(hexmap["2"], "#1f78b4");
-            equal(hexmap["1"], "#b2df8a");
-            equal(hexmap.abc, "#33a02c");
+            equal(hexmap.abc, "#008080");
+            equal(hexmap["1"], "#808000");
+            equal(hexmap["2"], "#a54700");
+            equal(hexmap["100"], "#00b6ff");
         });
         test("Test that useQuantScale = true works if only 2 numeric values", function () {
             var colorer = new Colorer(

--- a/tests/test-colorer.js
+++ b/tests/test-colorer.js
@@ -314,7 +314,7 @@ require([
                 undefined,
                 true
             );
-            // The last value in the color map (for viridis, dark purple)
+            // The last value in the color map (for viridis, yellow)
             // should be used.
             equal(colorer.__valueToColor.abc, "#fee825");
 

--- a/tests/test-colorer.js
+++ b/tests/test-colorer.js
@@ -127,14 +127,26 @@ require([
             equal(colorer.__valueToColor["3"], "#e6f5d0");
             equal(colorer.__valueToColor["4"], "#7fbc41");
         });
+        test("Test construction with a div. color map, all numeric values, and reverse", function () {
+            // Mostly same as the sequential + all numeric values test above,
+            // but just with a Colorer.DIVERGING color map that is reversed.
+            var eles = ["5", "2", "3", "1", "4", "-5"];
+            var colorer = new Colorer("PiYG", eles, false, undefined, true);
+            // Test extreme numeric values
+            equal(colorer.__valueToColor["5"], "#8e0152");
+            equal(colorer.__valueToColor["-5"], "#276419");
+            // Test intermediate numeric values
+            equal(colorer.__valueToColor["4"], "#de77ae");
+            equal(colorer.__valueToColor["3"], "#fde0ef");
+            equal(colorer.__valueToColor["2"], "#e6f5d0");
+            equal(colorer.__valueToColor["1"], "#7fbc41");
+        });
         test("Test construction with a div. color map, all numeric values, and useQuantScale = true", function () {
             var eles = ["5", "2", "3", "1", "4", "0", "-5"];
             var colorer = new Colorer("PiYG", eles, true);
 
-            // Expected colors determined by trying
-            // chroma.scale("PiYG").domain([-5,5])(n); where n = 0, 1, 2, etc.
-            // (see the interactive docs at https://gka.github.io/chroma.js/ --
-            // super useful for testing this)
+            // Expected colors determined by reversing
+            // the colors in the previous test
 
             // Test extreme numeric values
             equal(colorer.__valueToColor["-5"], "#8e0152");
@@ -167,6 +179,24 @@ require([
             equal(hexmap["2"], "#45075a");
             equal(hexmap["3"], "#450a5c");
             equal(hexmap["100"], "#fee825");
+        });
+        test("Test construction with a seq. color map, all numeric values, useQuantScale = true, and reverse = true", function () {
+            var colorer = new Colorer(
+                "Viridis",
+                ["1", "0", "100", "3", "2"],
+                true,
+                undefined,
+                true
+            );
+            hexmap = colorer.getMapHex();
+            equal(_.keys(hexmap).length, 5);
+            // As with above, (reversed here) expected colors determined by
+            // trying chroma.scale(chroma.brewer.Viridis).domain([100, 0])(n);
+            equal(hexmap["0"], "#fee825");
+            equal(hexmap["1"], "#f8e725");
+            equal(hexmap["2"], "#f2e626");
+            equal(hexmap["3"], "#ede626");
+            equal(hexmap["100"], "#440154");
         });
         test("Test construction with a seq. color map, numeric + non-numeric values, and useQuantScale = true", function () {
             // Same as the above test but with an extra non-numeric thing
@@ -296,6 +326,24 @@ require([
             equal(hexmap["1"], "#1f78b4");
             equal(hexmap["2"], "#b2df8a");
             equal(hexmap["100"], "#33a02c");
+        });
+        test("Test discrete color map with reverse = true", function () {
+            // CVALDISCRETETEST
+            var colorer = new Colorer(
+                "Paired",
+                ["1", "2", "100", "abc"],
+                false,
+                undefined,
+                true
+            );
+            hexmap = colorer.getMapHex();
+            equal(_.keys(hexmap).length, 4);
+            // Note that although "abc" is non-numeric it still gets assigned a
+            // (normal) color
+            equal(hexmap["100"], "#a6cee3");
+            equal(hexmap["2"], "#1f78b4");
+            equal(hexmap["1"], "#b2df8a");
+            equal(hexmap.abc, "#33a02c");
         });
         test("Test that useQuantScale = true works if only 2 numeric values", function () {
             var colorer = new Colorer(

--- a/tests/test-empress.js
+++ b/tests/test-empress.js
@@ -217,7 +217,6 @@ require([
                 "discrete-coloring-qiime",
                 "tip"
             );
-            let cm_copy = cm;
             var groups = ["1", "2"];
 
             // make sure '1' and '2' are the only gropus

--- a/tests/test-empress.js
+++ b/tests/test-empress.js
@@ -204,6 +204,7 @@ require([
                 "discrete-coloring-qiime",
                 "tip"
             );
+            let cm_copy = cm;
             var groups = ["1", "2"];
 
             // make sure '1' and '2' are the only gropus
@@ -236,27 +237,24 @@ require([
                 }
             }
 
-            // var old_cm1 = cm["1"];
-            // var old_cm2 = cm["2"];
-            // // test "tip" method with reverse = true
-            // cm = this.empress.colorByFeatureMetadata(
-            //     "f2",
-            //     "discrete-coloring-qiime",
-            //     "tip",
-            //     true
-            // );
-            // // check that current (reversed) cm1 is the same as old cm2
-            // deepEqual(
-            //     chroma(cm["1"]).gl().slice(0, 3),
-            //     chroma(old_cm2).gl().slice(0, 3),
-            //     "cm1 vs. old_cm2"
-            // );
-            // // same for other color
-            // deepEqual(
-            //     chroma(cm["2"]).gl().slice(0, 3),
-            //     chroma(old_cm1).gl().slice(0, 3),
-            //     "cm2 vs. old_cm1"
-            // );
+            // get color map with reverse = true
+            cm = this.empress.colorByFeatureMetadata(
+                "f1",
+                "discrete-coloring-qiime",
+                "tip",
+                true
+            );
+            // check that the color scales are flipped
+            deepEqual(
+                chroma(cm_copy["1"]).gl().slice(0, 3),
+                chroma(cm["2"]).gl().slice(0, 3),
+                "cm_copy['1'] vs. cm['2']"
+            );
+            deepEqual(
+                chroma(cm_copy["2"]).gl().slice(0, 3),
+                chroma(cm["1"]).gl().slice(0, 3),
+                "cm_copy['2'] vs. cm['1']"
+            );
 
             // test 'all' method
 

--- a/tests/test-empress.js
+++ b/tests/test-empress.js
@@ -188,6 +188,19 @@ require([
                     ]);
                 }
             }
+
+            cm = this.empress.colorBySampleCat(
+                "f1",
+                "discrete-coloring-qiime",
+                true
+            );
+            // check that the color scales are flipped
+            equal(chroma(cm.a).hex(), "#008080", "color 1 is last qiime color");
+            equal(
+                chroma(cm.b).hex(),
+                "#808000",
+                "color 2 is second last qiime color"
+            );
         });
 
         test("Test colorByFeatureMetadata, tip only", function () {

--- a/tests/test-empress.js
+++ b/tests/test-empress.js
@@ -236,6 +236,28 @@ require([
                 }
             }
 
+            // var old_cm1 = cm["1"];
+            // var old_cm2 = cm["2"];
+            // // test "tip" method with reverse = true
+            // cm = this.empress.colorByFeatureMetadata(
+            //     "f2",
+            //     "discrete-coloring-qiime",
+            //     "tip",
+            //     true
+            // );
+            // // check that current (reversed) cm1 is the same as old cm2
+            // deepEqual(
+            //     chroma(cm["1"]).gl().slice(0, 3),
+            //     chroma(old_cm2).gl().slice(0, 3),
+            //     "cm1 vs. old_cm2"
+            // );
+            // // same for other color
+            // deepEqual(
+            //     chroma(cm["2"]).gl().slice(0, 3),
+            //     chroma(old_cm1).gl().slice(0, 3),
+            //     "cm2 vs. old_cm1"
+            // );
+
             // test 'all' method
 
             cm = this.empress.colorByFeatureMetadata(

--- a/tests/test-empress.js
+++ b/tests/test-empress.js
@@ -245,15 +245,15 @@ require([
                 true
             );
             // check that the color scales are flipped
-            deepEqual(
-                chroma(cm_copy["1"]).gl().slice(0, 3),
-                chroma(cm["2"]).gl().slice(0, 3),
-                "cm_copy['1'] vs. cm['2']"
+            equal(
+                chroma(cm["1"]).hex(),
+                "#008080",
+                "color 1 is last qiime color"
             );
-            deepEqual(
-                chroma(cm_copy["2"]).gl().slice(0, 3),
-                chroma(cm["1"]).gl().slice(0, 3),
-                "cm_copy['2'] vs. cm['1']"
+            equal(
+                chroma(cm["2"]).hex(),
+                "#808000",
+                "color 1 is second last qiime color"
             );
 
             // test 'all' method


### PR DESCRIPTION
#418 

This PR adds functionality to Colorer to support reversing color maps. I have also integrated the reverse with the feature metadata coloring UI element.

You can see the feature in action [here](https://drive.google.com/file/d/1rGFY7TVp4eM9XoPmtvsXszomlkbFZfto/view?usp=sharing).

Notes/questions:

Custom color maps are not supported (my understanding is that the user supplies an object that performs the mapping, which is unordered, so cannot be “reversed”)

Are there other places where you would like me to implement the UI elements for reversing the color map?

Tests:

[x] Colorer with reverse=true works with discrete color map

[x] Colorer with reverse=true works with continuous color map

[x] Colorer with reverse=true works with ordinal color map

[x] Emperor.colorByFeatureMetadata switches the color values when reverse=true

