### PR TITLE
DOC: Remove Emperor installation note, and also bump the version number in setup.py to 1.0.1-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,7 @@ conda activate qiime2-2020.8
 
 You can replace `qiime2-2020.8` above with whichever version of QIIME 2 you have currently installed.  
 
-Now we are ready to install Empress. Run the following commands to do so. (Note
-that Emperor will be _re-installed_ when the second command is run; the reason
-we uninstall it first is so that we can ensure the most up-to-date version of
-it is available.)
+Now we are ready to install Empress. Run the following commands to do so.
 
 ```
 pip install empress

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@
 
 from setuptools import setup, find_packages
 
-__version__ = "1.0.1"
+__version__ = "1.0.1-dev"
 __maintainer__ = "Empress development team"
 __email__ = "kcantrel@ucsd.edu"
 


### PR DESCRIPTION
This note was there to caution readers that the
`pip uninstall --yes emperor` line would only temporarily uninstall
Emperor, since Emperor would immediately get reinstalled when
installing Empress afterwards.

Now that the Emperor uninstallation line isn't present in the
README instructions any more, we should just remove this note.

(Sorry for not catching this in review, I just realized it ._.)

edit: I also bumped up the version number in setup.py to `1.0.1-dev` now that i think about it