### PR TITLE
NEW warn when layout options (approximately) do not change branch lengths

### DIFF
--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -373,6 +373,9 @@ define([
         var data, i;
         // set up length getter
         var branchMethod = this.branchMethod;
+        var checkLengthsChange = LayoutsUtil.shouldCheckBranchLengthsChanged(
+            branchMethod
+        );
         var lengthGetter = LayoutsUtil.getLengthMethod(
             branchMethod,
             this._tree
@@ -392,7 +395,8 @@ define([
                 // what lengths it should lay out.
                 this.leafSorting,
                 undefined,
-                lengthGetter
+                lengthGetter,
+                checkLengthsChange
             );
             this._yrscf = data.yScalingFactor;
             for (i = 1; i <= this._tree.size; i++) {
@@ -414,7 +418,8 @@ define([
                 4020,
                 this.leafSorting,
                 undefined,
-                lengthGetter
+                lengthGetter,
+                checkLengthsChange
             );
             for (i = 1; i <= this._tree.size; i++) {
                 // remove old layout information
@@ -439,7 +444,8 @@ define([
                 4020,
                 4020,
                 undefined,
-                lengthGetter
+                lengthGetter,
+                checkLengthsChange
             );
             for (i = 1; i <= this._tree.size; i++) {
                 // remove old layout information

--- a/empress/support_files/js/layouts-util.js
+++ b/empress/support_files/js/layouts-util.js
@@ -373,7 +373,8 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
             }
             anyDifferent =
                 // this expression assumes nodeLen and tree.length will both be positive
-                anyDifferent || Math.abs((tree.length(prepos) / nodeLen) - 1) > TOL;
+                anyDifferent ||
+                Math.abs(tree.length(prepos) / nodeLen - 1) > TOL;
         }
         if (!anyDifferent && checkLengthsChange) {
             noLengthsChangedMsg();

--- a/empress/support_files/js/layouts-util.js
+++ b/empress/support_files/js/layouts-util.js
@@ -160,6 +160,7 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
      * @param {String} methodName Method for determing branch lengths.
      *                            One of ("ultrametric", "ignore", "normal").
      * @returns {Boolean} Indicates whether the check should be performed.
+     * @throws {Error} If methodName is invalid.
      */
     function shouldCheckBranchLengthsChanged(methodName) {
         var methods = {
@@ -175,7 +176,8 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
     }
 
     var NO_LENGTHS_CHANGED_MSG =
-        "No branch lengths modified by layout options.";
+        "It doesn't look like any branch lengths were changed " +
+        "by the current method of modifying branch lengths.";
     var NO_LENGTHS_CHANGED_DURATION = 3000;
     var TOL = 0.000001;
 

--- a/empress/support_files/js/layouts-util.js
+++ b/empress/support_files/js/layouts-util.js
@@ -159,7 +159,7 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
      *
      * @param {String} methodName Method for determing branch lengths.
      *                            One of ("ultrametric", "ignore", "normal").
-     * @returns {Function} A function that maps node indices to branch lengths.
+     * @returns {Boolean} Indicates whether the check should be performed.
      */
     function shouldCheckBranchLengthsChanged(methodName) {
         var methods = {

--- a/empress/support_files/js/layouts-util.js
+++ b/empress/support_files/js/layouts-util.js
@@ -373,10 +373,7 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
             if (maxWidth < xCoord[node]) {
                 maxWidth = xCoord[node];
             }
-            anyDifferent =
-                // this expression assumes nodeLen and tree.length will both be positive
-                anyDifferent ||
-                Math.abs(tree.length(prepos) / nodeLen - 1) > TOL;
+            anyDifferent = updateAnyDifferent(anyDifferent, nodeLen, tree, prepos);
         }
         if (!anyDifferent && checkLengthsChange) {
             noLengthsChangedMsg();
@@ -619,8 +616,7 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
 
             var nodeLen = lengthGetter(prepos);
             radius[node] = radius[parent] + nodeLen;
-            anyDifferent =
-                anyDifferent || Math.abs(nodeLen - tree.length(prepos)) > TOL;
+            anyDifferent = updateAnyDifferent(anyDifferent, nodeLen, tree, prepos);
         }
         if (!anyDifferent && checkLengthsChange) {
             noLengthsChangedMsg();
@@ -748,6 +744,23 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
     }
 
     /**
+     *
+     * @param {Boolean} anyDifferent Indicates if any branches have different
+     *                               transformed lengths that differ from
+     *                               their original length in the tree.
+     * @param {Float} branchLen Transformed length of the branch.
+     * @param {BPTree} tree That has (potentially) been transformed.
+     * @param {Number} n Node index in tree.
+     * @returns {Boolean} Indicates if any of the branches checked in the tree
+     *                    so far are different than the transformed length.
+     */
+    function updateAnyDifferent(anyDifferent, branchLen, tree, n) {
+        anyDifferent =
+            anyDifferent || Math.abs(branchLen - tree.length(n)) > TOL;
+        return anyDifferent;
+    }
+
+    /**
      * Unrooted layout.
      *
      * REFERENCES
@@ -837,9 +850,7 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
             minX = Math.min(minX, x2Arr[node]);
             maxY = Math.max(maxY, y2Arr[node]);
             minY = Math.min(minY, y2Arr[node]);
-
-            anyDifferent =
-                anyDifferent || Math.abs(nodeLen - tree.length(n)) > TOL;
+            anyDifferent = updateAnyDifferent(anyDifferent, nodeLen, tree, n);
         }
         if (!anyDifferent && checkLengthsChange) {
             noLengthsChangedMsg();

--- a/empress/support_files/js/layouts-util.js
+++ b/empress/support_files/js/layouts-util.js
@@ -619,7 +619,7 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
             var nodeLen = lengthGetter(prepos);
             radius[node] = radius[parent] + nodeLen;
             if (checkLengthsChange && !anyDifferent) {
-                anyDifferent = isTransformedLenDifferent(nodeLen, tree, n);
+                anyDifferent = isTransformedLenDifferent(nodeLen, tree, prepos);
             }
         }
         if (checkLengthsChange && !anyDifferent) {
@@ -758,7 +758,7 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
      *                    different from its original length.
      */
     function isTransformedLenDifferent(branchLen, tree, n) {
-        return Math.abs(branchLen - tree.length(n)) > TOL;
+        return Math.abs(tree.length(n) / branchLen - 1) > TOL;
     }
 
     /**

--- a/empress/support_files/js/layouts-util.js
+++ b/empress/support_files/js/layouts-util.js
@@ -608,7 +608,6 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
 
             var nodeLen = lengthGetter(prepos);
             radius[node] = radius[parent] + nodeLen;
-            // anyDifferent = anyDifferent || nodeLen !== tree.length(prepos);
             anyDifferent =
                 anyDifferent || Math.abs(nodeLen - tree.length(prepos)) > TOL;
         }
@@ -828,7 +827,6 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
             maxY = Math.max(maxY, y2Arr[node]);
             minY = Math.min(minY, y2Arr[node]);
 
-            // anyDifferent = anyDifferent || nodeLen !== tree.length(n);
             anyDifferent =
                 anyDifferent || Math.abs(nodeLen - tree.length(n)) > TOL;
         }

--- a/empress/support_files/js/layouts-util.js
+++ b/empress/support_files/js/layouts-util.js
@@ -374,12 +374,7 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
                 maxWidth = xCoord[node];
             }
             if (checkLengthsChange && !anyDifferent) {
-                anyDifferent = updateAnyDifferent(
-                    anyDifferent,
-                    nodeLen,
-                    tree,
-                    prepos
-                );
+                anyDifferent = isTransformedLenDifferent(nodeLen, tree, n);
             }
         }
         if (checkLengthsChange && !anyDifferent) {
@@ -624,12 +619,7 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
             var nodeLen = lengthGetter(prepos);
             radius[node] = radius[parent] + nodeLen;
             if (checkLengthsChange && !anyDifferent) {
-                anyDifferent = updateAnyDifferent(
-                    anyDifferent,
-                    nodeLen,
-                    tree,
-                    prepos
-                );
+                anyDifferent = isTransformedLenDifferent(nodeLen, tree, n);
             }
         }
         if (checkLengthsChange && !anyDifferent) {
@@ -758,20 +748,17 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
     }
 
     /**
+     * Returns true if a given node (a.k.a. branch) in the tree has a
+     * transformed length differing from its original length.
      *
-     * @param {Boolean} anyDifferent Indicates if any branches have different
-     *                               transformed lengths that differ from
-     *                               their original length in the tree.
      * @param {Float} branchLen Transformed length of the branch.
      * @param {BPTree} tree That has (potentially) been transformed.
      * @param {Number} n Node index in tree.
-     * @returns {Boolean} Indicates if any of the branches checked in the tree
-     *                    so far are different than the transformed length.
+     * @returns {Boolean} Indicates if this branch's transformed length is
+     *                    different from its original length.
      */
-    function updateAnyDifferent(anyDifferent, branchLen, tree, n) {
-        anyDifferent =
-            anyDifferent || Math.abs(branchLen - tree.length(n)) > TOL;
-        return anyDifferent;
+    function isTransformedLenDifferent(branchLen, tree, n) {
+        return Math.abs(branchLen - tree.length(n)) > TOL;
     }
 
     /**
@@ -865,12 +852,7 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
             maxY = Math.max(maxY, y2Arr[node]);
             minY = Math.min(minY, y2Arr[node]);
             if (checkLengthsChange && !anyDifferent) {
-                anyDifferent = updateAnyDifferent(
-                    anyDifferent,
-                    nodeLen,
-                    tree,
-                    n
-                );
+                anyDifferent = isTransformedLenDifferent(nodeLen, tree, n);
             }
         }
         if (checkLengthsChange && !anyDifferent) {

--- a/empress/support_files/js/layouts-util.js
+++ b/empress/support_files/js/layouts-util.js
@@ -374,7 +374,7 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
                 maxWidth = xCoord[node];
             }
             if (checkLengthsChange && !anyDifferent) {
-                anyDifferent = isTransformedLenDifferent(nodeLen, tree, n);
+                anyDifferent = isTransformedLenDifferent(nodeLen, tree, prepos);
             }
         }
         if (checkLengthsChange && !anyDifferent) {

--- a/empress/support_files/js/layouts-util.js
+++ b/empress/support_files/js/layouts-util.js
@@ -180,6 +180,13 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
     var TOL = 0.000001;
 
     /**
+     * Raises a toast message telling the user that no branch lengths changed.
+     */
+    function noLengthsChangedMsg() {
+        util.toastMsg(NO_LENGTHS_CHANGED_MSG, NO_LENGTHS_CHANGED_DURATION);
+    }
+
+    /**
      * Computes the "scale factor" for the circular / unrooted layouts.
      *
      * NOTE that we don't bother with this for the rectangular layout since --
@@ -369,7 +376,7 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
                 anyDifferent || Math.abs((tree.length(prepos) / nodeLen) - 1) > TOL;
         }
         if (!anyDifferent && checkLengthsChange) {
-            util.toastMsg(NO_LENGTHS_CHANGED_MSG, NO_LENGTHS_CHANGED_DURATION);
+            noLengthsChangedMsg();
         }
 
         // We don't check if max_width == 0 here, because we check when
@@ -613,7 +620,7 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
                 anyDifferent || Math.abs(nodeLen - tree.length(prepos)) > TOL;
         }
         if (!anyDifferent && checkLengthsChange) {
-            util.toastMsg(NO_LENGTHS_CHANGED_MSG, NO_LENGTHS_CHANGED_DURATION);
+            noLengthsChangedMsg();
         }
 
         // Now that we have the polar coordinates of the nodes, convert them to
@@ -832,7 +839,7 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
                 anyDifferent || Math.abs(nodeLen - tree.length(n)) > TOL;
         }
         if (!anyDifferent && checkLengthsChange) {
-            util.toastMsg(NO_LENGTHS_CHANGED_MSG, NO_LENGTHS_CHANGED_DURATION);
+            noLengthsChangedMsg();
         }
         if (normalize) {
             var scaleFactor = computeScaleFactor(

--- a/empress/support_files/js/layouts-util.js
+++ b/empress/support_files/js/layouts-util.js
@@ -177,7 +177,7 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
     var NO_LENGTHS_CHANGED_MSG =
         "No branch lengths modified by layout options.";
     var NO_LENGTHS_CHANGED_DURATION = 3000;
-    var TOL = 0.0000001;
+    var TOL = 0.000001;
 
     /**
      * Computes the "scale factor" for the circular / unrooted layouts.
@@ -365,7 +365,8 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
                 maxWidth = xCoord[node];
             }
             anyDifferent =
-                anyDifferent || Math.abs(nodeLen - tree.length(prepos)) > TOL;
+                // this expression assumes nodeLen and tree.length will both be positive
+                anyDifferent || Math.abs((tree.length(prepos) / nodeLen) - 1) > TOL;
         }
         if (!anyDifferent && checkLengthsChange) {
             util.toastMsg(NO_LENGTHS_CHANGED_MSG, NO_LENGTHS_CHANGED_DURATION);

--- a/empress/support_files/js/layouts-util.js
+++ b/empress/support_files/js/layouts-util.js
@@ -154,6 +154,13 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
         return lengthGetter;
     }
 
+    /**
+     * Determines whether a given method should check if branch lengths were changed.
+     *
+     * @param {String} methodName Method for determing branch lengths.
+     *                            One of ("ultrametric", "ignore", "normal").
+     * @returns {Function} A function that maps node indices to branch lengths.
+     */
     function shouldCheckBranchLengthsChanged(methodName) {
         var methods = {
             ultrametric: true,
@@ -284,6 +291,9 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
      *                                that corresponds to the index of a node in
      *                                tree. Returns the length of the node at that
      *                                index. Defaults to 'normal' method.
+     * @param {Boolean} checkLengthsChange If true, then a warning will be raised
+     *                                     if no branch lengths in the tree differ
+     *                                     from the value determined by lengthGetter.
      * @return {Object} Object with the following properties:
      *                   -xCoords
      *                   -yCoords
@@ -498,6 +508,9 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
      *                                that corresponds to the index of a node in
      *                                tree. Returns the length of the node at that
      *                                index. Defaults to 'normal' method.
+     * @param {Boolean} checkLengthsChange If true, then a warning will be raised
+     *                                     if no branch lengths in the tree differ
+     *                                     from the value determined by lengthGetter.
      * @return {Object} Object with the following properties:
      *                   -x0, y0 ("starting point" x and y)
      *                   -x1, y1 ("ending point" x and y)
@@ -742,6 +755,9 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
      *                                that corresponds to the index of a node in
      *                                tree. Returns the length of the node at that
      *                                index. Defaults to 'normal' method.
+     * @param {Boolean} checkLengthsChange If true, then a warning will be raised
+     *                                     if no branch lengths in the tree differ
+     *                                     from the value determined by lengthGetter.
      * @return {Object} Object with the following properties:
      *                   -xCoords
      *                   -yCoords

--- a/empress/support_files/js/layouts-util.js
+++ b/empress/support_files/js/layouts-util.js
@@ -373,9 +373,16 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
             if (maxWidth < xCoord[node]) {
                 maxWidth = xCoord[node];
             }
-            anyDifferent = updateAnyDifferent(anyDifferent, nodeLen, tree, prepos);
+            if (checkLengthsChange && !anyDifferent) {
+                anyDifferent = updateAnyDifferent(
+                    anyDifferent,
+                    nodeLen,
+                    tree,
+                    prepos
+                );
+            }
         }
-        if (!anyDifferent && checkLengthsChange) {
+        if (checkLengthsChange && !anyDifferent) {
             noLengthsChangedMsg();
         }
 
@@ -616,9 +623,16 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
 
             var nodeLen = lengthGetter(prepos);
             radius[node] = radius[parent] + nodeLen;
-            anyDifferent = updateAnyDifferent(anyDifferent, nodeLen, tree, prepos);
+            if (checkLengthsChange && !anyDifferent) {
+                anyDifferent = updateAnyDifferent(
+                    anyDifferent,
+                    nodeLen,
+                    tree,
+                    prepos
+                );
+            }
         }
-        if (!anyDifferent && checkLengthsChange) {
+        if (checkLengthsChange && !anyDifferent) {
             noLengthsChangedMsg();
         }
 
@@ -850,9 +864,16 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
             minX = Math.min(minX, x2Arr[node]);
             maxY = Math.max(maxY, y2Arr[node]);
             minY = Math.min(minY, y2Arr[node]);
-            anyDifferent = updateAnyDifferent(anyDifferent, nodeLen, tree, n);
+            if (checkLengthsChange && !anyDifferent) {
+                anyDifferent = updateAnyDifferent(
+                    anyDifferent,
+                    nodeLen,
+                    tree,
+                    n
+                );
+            }
         }
-        if (!anyDifferent && checkLengthsChange) {
+        if (checkLengthsChange && !anyDifferent) {
             noLengthsChangedMsg();
         }
         if (normalize) {


### PR DESCRIPTION
Fixes #447 .

This PR follows up on #444 to raise a toast message if the tree is not changed by options like "make ultrametric" and "ignore branch lengths".

When working on a tree from qemistree (thanks @gibsramen ), I found that the branch lengths could be modified by small amounts by the make ultrametric code, but this resulted in no visible difference between the two trees. As a result, I introduced a tolerance for how similar branch lengths should be in order to make this warning. Though this could result in a warning being falsely raised in the case where the branch lengths in the tree are all very small.

![Screen Shot 2020-11-25 at 11 05 42 AM](https://user-images.githubusercontent.com/19470970/100271354-3890e680-2f0e-11eb-8145-abe1891cae6d.png)
