### PR TITLE
[WIP] NEW spectrum color picker for legend on feature/sample metadata coloring

### DIFF
--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -2312,7 +2312,7 @@ define([
         return keyInfo;
     };
 
-    Empress.prototype._updateLegendFromModel = function(obs) {
+    Empress.prototype._updateLegendFromModel = function (obs) {
         // A few known issues:
         // Legend changes are not kept on:
         // * changing collapse
@@ -2330,7 +2330,7 @@ define([
             // this allows us to recolor collapsed clades
             if (!_.isEmpty(scope._collapsedClades)) {
                 _.map(scope._collapsedClades, (info, node) => {
-                    var color = scope.getNodeInfo(node, 'color');
+                    var color = scope.getNodeInfo(node, "color");
                     info.color = color;
                 });
                 scope.collapseClades();

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -2124,8 +2124,9 @@ define([
         color,
         reverse = false
     ) {
+        var scope = this;
         this.resetUpdateColorMap();
-        this._legend.disableUpdate();
+        // this._legend.disableUpdate();
         var tree = this._tree;
         var obs = this._biom.getObsBy(cat);
         var categories = Object.keys(obs);
@@ -2168,8 +2169,17 @@ define([
         // assigns node in obs to groups in this._groups
         this.assignGroups(obs);
 
-        // color tree
-        this._colorTree(obs, cm);
+        // TODO also remove this from feature metadata
+        // // color tree
+        // this._colorTree(obs, cm);
+
+        this._legend.enableUpdate();
+        this.updateColorMap = function() {
+            var hexmap = scope._legend_model.getColorMap();
+            var rgbmap = _.mapObject(hexmap, Colorer.hex2RGB);
+            scope._colorTree(obs, rgbmap);
+            scope.drawTree();
+        };
 
         this.updateLegendCategorical(cat, keyInfo);
 
@@ -2306,8 +2316,8 @@ define([
         // assigns nodes in to a group in this._group array
         this.assignGroups(obs);
 
-        // color tree
-        this._colorTree(obs, cm);
+        // // color tree
+        // this._colorTree(obs, cm);
 
 
         this._legend.enableUpdate();
@@ -2320,7 +2330,6 @@ define([
         };
 
         this.updateLegendCategorical(cat, keyInfo);
-        // scope._legend_model.notify();
 
         return keyInfo;
     };

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -2124,7 +2124,6 @@ define([
         color,
         reverse = false
     ) {
-        this.resetUpdateLegend();
         var tree = this._tree;
         var obs = this._biom.getObsBy(cat);
         var categories = Object.keys(obs);
@@ -2312,6 +2311,14 @@ define([
         return keyInfo;
     };
 
+    /**
+     * A method for updating tree coloring from _legendModel
+     *
+     * @param{Object} obs Maps categories to the unique nodes to be colored for
+     *                    each category.
+     * @returns {Function} Function to be called when the LegendModel updates.
+     * @private
+     */
     Empress.prototype._updateLegendFromModel = function (obs) {
         // A few known issues:
         // Legend changes are not kept on:
@@ -2339,10 +2346,10 @@ define([
         };
     };
 
-    Empress.prototype.resetUpdateLegend = function () {
-        this.updateLegend = () => {};
-    };
-
+    /**
+     * Function called when there is an update to any LegendModel that
+     * Empress subscribes to.
+     */
     Empress.prototype.updateLegend = function () {};
 
     /*

--- a/empress/support_files/js/legend.js
+++ b/empress/support_files/js/legend.js
@@ -1,7 +1,12 @@
 define(["jquery", "underscore", "util", "spectrum"], function ($, _, util, spectrum) {
 
     function ColorEditor(args) {
-        var scope = this;
+        // TODO
+        // NOTE: We are having trouble getting the spectrum picker to show
+        //  on initialization...
+        //  Additionally, it seems like the colorbox class adds a border and
+        //  changes the shape of the ColorCell and we would prefer to not
+        //  do that.
         this.$input = $("<div class='colorbox'></div>");
         this.$input.appendTo($(args.container));
 
@@ -22,16 +27,11 @@ define(["jquery", "underscore", "util", "spectrum"], function ($, _, util, spect
             /* On change callback */
             change: function(color) {
                 const col = color.toHexString();
-                // args.container.setAttribute("style", "background: " + col + ";");
                 var map = {};
                 map[args.colorKey] = col;
                 args.controller.remapColors(map);
-                scope.$input.spectrum('hide');
-                scope.$input.spectrum('destroy');
-                scope.$input.remove();
             }
         });
-
     }
 
     function LegendModel(map) {

--- a/empress/support_files/js/legend.js
+++ b/empress/support_files/js/legend.js
@@ -71,7 +71,7 @@ define(["jquery", "underscore", "util", "spectrum"], function (
     /**
      * Resets the legend.
      */
-    LegendModel.prototype.clear = function() {
+    LegendModel.prototype.clear = function () {
         this.map = {};
         this.name = undefined;
         // not notifying...
@@ -94,7 +94,7 @@ define(["jquery", "underscore", "util", "spectrum"], function (
     LegendModel.prototype.unregisterObserver = function (observer) {
         const index = this.observers.indexOf(observer);
         if (index > -1) {
-          array.splice(index, 1);
+            array.splice(index, 1);
         }
     };
 

--- a/empress/support_files/js/legend.js
+++ b/empress/support_files/js/legend.js
@@ -437,6 +437,10 @@ define(["jquery", "underscore", "util", "spectrum"], function (
         this.model.setColorMap(info);
     };
 
+    /**
+     * Updates the legend by pulling legend info from the model. This is the
+     * requisite function to implement the LegendObserver interface.
+     */
     Legend.prototype.updateLegend = function () {
         var scope = this;
         this.clear();

--- a/empress/support_files/js/legend.js
+++ b/empress/support_files/js/legend.js
@@ -94,7 +94,7 @@ define(["jquery", "underscore", "util", "spectrum"], function (
     LegendModel.prototype.unregisterObserver = function (observer) {
         const index = this.observers.indexOf(observer);
         if (index > -1) {
-            array.splice(index, 1);
+            this.observers.splice(index, 1);
         }
     };
 
@@ -280,6 +280,18 @@ define(["jquery", "underscore", "util", "spectrum"], function (
         this._minLengthVal = null;
         this._maxLengthVal = null;
     }
+
+    /**
+     * @type {Function}
+     * The constructor of the model for the legend.
+     */
+    Legend.modelConstructor = LegendModel;
+
+    /**
+     * @type {Function}
+     * The constructor of the controller for the legend.
+     */
+    Legend.controllerConstructor = LegendController;
 
     /**
      * Enables the legend to be updated with a spectrum color picker

--- a/tests/test-legend.js
+++ b/tests/test-legend.js
@@ -36,6 +36,18 @@ require([
                     ok(ele.classList.contains("legend-title"));
                     equal(ele.innerText, expText);
                 };
+
+                class MockLegendObserver {
+                    constructor() {
+                        this.notified = 0;
+                    }
+
+                    updateLegend() {
+                        this.notified++;
+                    }
+                }
+
+                this.mockLegendObserver = MockLegendObserver;
             },
             teardown: function () {
                 this.containerEle.remove();
@@ -328,6 +340,57 @@ require([
             equal(this.containerEle.children.length, 2);
             this.validateTitleEle(this.containerEle.children[1], titleText2);
             equal(legend.title, titleText2);
+        });
+        test("LegendModel Register Observer", function () {
+            var model = new Legend.modelConstructor();
+            var observer = new this.mockLegendObserver();
+            model.registerObserver(observer);
+            deepEqual(model.observers, [observer]);
+        });
+        test("LegendModel notify observer", function () {
+            var model = new Legend.modelConstructor();
+            var observer = new this.mockLegendObserver();
+            model.registerObserver(observer);
+            // the mock observer should increment its notified count
+            model.notify();
+            equal(observer.notified, 1);
+            model.notify();
+            equal(observer.notified, 2);
+        });
+        test("LegendModel unregister observer", function () {
+            var model = new Legend.modelConstructor();
+            var observer = new this.mockLegendObserver();
+            model.registerObserver(observer);
+            // the mock observer should increment its notified count
+            model.notify();
+            equal(observer.notified, 1);
+            model.unregisterObserver(observer);
+            model.notify();
+            equal(observer.notified, 1);
+        });
+        test("LegendModel notify on updateColorMap", function () {
+            var model = new Legend.modelConstructor();
+            var observer = new this.mockLegendObserver();
+            model.registerObserver(observer);
+            // the observer should be notified when the color map is updated
+            model.updateColorMap({ key: "val" });
+            equal(observer.notified, 1);
+        });
+        test("LegendModel notify on setColorMap", function () {
+            var model = new Legend.modelConstructor();
+            var observer = new this.mockLegendObserver();
+            model.registerObserver(observer);
+            // the observer should be notified when the color map is updated
+            model.setColorMap({ key: "val" });
+            equal(observer.notified, 1);
+        });
+        test("LegendModel notify on setName", function () {
+            var model = new Legend.modelConstructor();
+            var observer = new this.mockLegendObserver();
+            model.registerObserver(observer);
+            // the observer should be notified when the color map is updated
+            model.setName("LegendName");
+            equal(observer.notified, 1);
         });
     });
 });


### PR DESCRIPTION
@kwcantrell and I put together a draft of recoloring the tree's feature/sample metadata coloring with a spectrum picker.

Currently a few caveats:
* Colors are reset when clades are collapsed (i.e., if you change your legend then collapse clades, it will revert to the original color scale).
* Thickened lines do not reflect updated legends.
* We cannot yet update barplot legends.

Each of these is doable, but requires more interaction/re-working other parts of the code base, so we wanted to get feedback on the initial design first.

Progress on #368 