### PR TITLE
Add option to adjust gap between tree and first barplot layer

### DIFF
--- a/empress/support_files/js/barplot-panel-handler.js
+++ b/empress/support_files/js/barplot-panel-handler.js
@@ -55,6 +55,7 @@ define([
         this.borderContent = document.getElementById("barplot-border-content");
         this.borderCheckbox = document.getElementById("barplot-border-chk");
         this.borderOptions = document.getElementById("barplot-border-options");
+        this.borderGapInput = document.getElementById("barplot-custom-gap");
         this.borderColorPicker = document.getElementById(
             "barplot-border-color"
         );
@@ -129,6 +130,7 @@ define([
 
         // And define behavior for how to add in barplots
         this.updateButton.onclick = function () {
+            scope.empress.changeBorderGap(scope.borderGap);
             scope.empress.drawBarplots(scope.layers);
         };
 
@@ -142,6 +144,7 @@ define([
         // ... and to having a length of whatever the default barplot layer
         // length divided by 10 is :)
         this.borderLength = BarplotLayer.DEFAULT_LENGTH / 10;
+        this.borderGap = 10;
 
         // Now, initialize the border options UI accordingly
         this.initBorderOptions();
@@ -158,8 +161,17 @@ define([
             }
         };
 
+        // Define behavior for border gap input
+        this.borderGapInput.value = this.borderGap;
+        console.log("Default set!");
+        console.log(this.borderGapInput.value);
+        $(this.borderGapInput).change(function () {
+            scope.borderGap = this.value;
+        });
+
         // To get things started off with, let's add a layer
         this.addLayer();
+
     }
 
     /**

--- a/empress/support_files/js/barplot-panel-handler.js
+++ b/empress/support_files/js/barplot-panel-handler.js
@@ -146,7 +146,7 @@ define([
 
         // Initialize default spacing between tree and first barplot layer
         // as well as change behavior.
-        this.borderGap = 5;
+        this.borderGapInput.value = 5;
         $(this.borderGapInput).change(function () {
             var gapInput = util.parseAndValidateNum(scope.borderGapInput, 0);
             scope.empress._displacementFrac = gapInput / 100;
@@ -166,12 +166,6 @@ define([
                 scope.useBorders = false;
             }
         };
-
-        // Define behavior for border gap input
-        this.borderGapInput.value = this.borderGap;
-        $(this.borderGapInput).change(function () {
-            scope.borderGap = this.value;
-        });
 
         // To get things started off with, let's add a layer
         this.addLayer();

--- a/empress/support_files/js/barplot-panel-handler.js
+++ b/empress/support_files/js/barplot-panel-handler.js
@@ -148,9 +148,7 @@ define([
         // as well as change behavior.
         this.borderGap = 5;
         $(this.borderGapInput).change(function () {
-            var gapInput = util.parseAndValidateNum(
-                scope.borderGapInput, 0
-            );
+            var gapInput = util.parseAndValidateNum(scope.borderGapInput, 0);
             scope.empress._displacementFrac = gapInput / 100;
         });
 
@@ -177,7 +175,6 @@ define([
 
         // To get things started off with, let's add a layer
         this.addLayer();
-
     }
 
     /**

--- a/empress/support_files/js/barplot-panel-handler.js
+++ b/empress/support_files/js/barplot-panel-handler.js
@@ -146,7 +146,7 @@ define([
 
         // Initialize default spacing between tree and first barplot layer
         // as well as change behavior.
-        this.borderGap = 10;
+        this.borderGap = 5;
         $(this.borderGapInput).change(function () {
             var gapInput = util.parseAndValidateNum(
                 scope.borderGapInput, 0

--- a/empress/support_files/js/barplot-panel-handler.js
+++ b/empress/support_files/js/barplot-panel-handler.js
@@ -146,7 +146,8 @@ define([
 
         // Initialize default spacing between tree and first barplot layer
         // as well as change behavior.
-        this.distBtwnTreeAndBarplots = BarplotPanel.DEFAULT_DIST_BTWN_TREE_AND_BARPLOTS;
+        this.distBtwnTreeAndBarplots =
+            BarplotPanel.DEFAULT_DIST_BTWN_TREE_AND_BARPLOTS;
         this.borderGapInput.value = this.distBtwnTreeAndBarplots;
         $(this.borderGapInput).change(function () {
             var gapInput = util.parseAndValidateNum(scope.borderGapInput, 0);

--- a/empress/support_files/js/barplot-panel-handler.js
+++ b/empress/support_files/js/barplot-panel-handler.js
@@ -146,10 +146,11 @@ define([
 
         // Initialize default spacing between tree and first barplot layer
         // as well as change behavior.
-        this.borderGapInput.value = 5;
+        this.distBtwnTreeAndBarplots = BarplotPanel.DEFAULT_DIST_BTWN_TREE_AND_BARPLOTS;
+        this.borderGapInput.value = this.distBtwnTreeAndBarplots;
         $(this.borderGapInput).change(function () {
             var gapInput = util.parseAndValidateNum(scope.borderGapInput, 0);
-            scope.empress._displacementFrac = gapInput / 100;
+            scope.distBtwnTreeAndBarplots = gapInput;
         });
 
         // Now, initialize the border options UI accordingly
@@ -330,6 +331,13 @@ define([
      * Array containing the names of layouts compatible with barplots.
      */
     BarplotPanel.SUPPORTED_LAYOUTS = ["Rectangular", "Circular"];
+
+    /**
+     * Default distance (in "barplot units," the same as used for barplot
+     * lengths) between the farthest point on the tree and the start of the
+     * first barplot layer.
+     */
+    BarplotPanel.DEFAULT_DIST_BTWN_TREE_AND_BARPLOTS = 10;
 
     return BarplotPanel;
 });

--- a/empress/support_files/js/barplot-panel-handler.js
+++ b/empress/support_files/js/barplot-panel-handler.js
@@ -130,7 +130,6 @@ define([
 
         // And define behavior for how to add in barplots
         this.updateButton.onclick = function () {
-            scope.empress.changeBorderGap(scope.borderGap);
             scope.empress.drawBarplots(scope.layers);
         };
 
@@ -144,7 +143,16 @@ define([
         // ... and to having a length of whatever the default barplot layer
         // length divided by 10 is :)
         this.borderLength = BarplotLayer.DEFAULT_LENGTH / 10;
+
+        // Initialize default spacing between tree and first barplot layer
+        // as well as change behavior.
         this.borderGap = 10;
+        $(this.borderGapInput).change(function () {
+            var gapInput = util.parseAndValidateNum(
+                scope.borderGapInput, 0
+            );
+            scope.empress._displacementFrac = gapInput / 100;
+        });
 
         // Now, initialize the border options UI accordingly
         this.initBorderOptions();

--- a/empress/support_files/js/barplot-panel-handler.js
+++ b/empress/support_files/js/barplot-panel-handler.js
@@ -163,8 +163,6 @@ define([
 
         // Define behavior for border gap input
         this.borderGapInput.value = this.borderGap;
-        console.log("Default set!");
-        console.log(this.borderGapInput.value);
         $(this.borderGapInput).change(function () {
             scope.borderGap = this.value;
         });

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -239,6 +239,13 @@ define([
 
         /**
          * @type {Number}
+         * Determines the fraction of _maxDisplacement to use as the gap
+         * between the first barplot layer and the closest-to-root point.
+         */
+        this._displacementFrac = 0.1;
+
+        /**
+         * @type {Number}
          * A multiple of this._maxDisplacement. This is used as the unit for
          * barplot lengths.
          * @private
@@ -1139,6 +1146,11 @@ define([
         this._addTriangleCoords(coords, corners, color);
     };
 
+    Empress.prototype.changeBorderGap = function (width) {
+        this._displacementFrac = width / 100;
+        console.log(this._maxDisplacement);
+    };
+
     /**
      * Thickens the colored branches of the tree.
      *
@@ -1496,7 +1508,7 @@ define([
         // displacement (this looks kinda bad because the node circle of the
         // tip(s) at this max displacement are partially covered by the
         // barplots, so we don't do that).
-        var maxD = 1.1 * this._maxDisplacement;
+        var maxD = (1 + this._displacementFrac) * this._maxDisplacement;
 
         // As we iterate through the layers, we'll store the "previous layer
         // max D" as a separate variable. This will help us easily work with

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -239,14 +239,6 @@ define([
 
         /**
          * @type {Number}
-         * Determines the fraction of _maxDisplacement to use as the gap
-         * between the first barplot layer and the closest-to-root point.
-         * @private
-         */
-        this._displacementFrac = 0.05;
-
-        /**
-         * @type {Number}
          * A multiple of this._maxDisplacement. This is used as the unit for
          * barplot lengths.
          * @private
@@ -1496,14 +1488,14 @@ define([
         var barplotBuffer = [];
 
         // Add on a gap between the closest-to-the-root point at which we can
-        // start drawing barplots, and the first barplot layer. This could be
-        // made into a barplot-panel-level configurable thing if desired.
-        // Defaults to 1.05 * max displacement. If we used a 1.0 term instead,
-        // then barplots would start immediately at the max displacement (this
-        // looks kinda bad because the node circle of the tip(s) at this max
-        // displacement are partially covered by the barplots, so we don't do
-        // that).
-        var maxD = (1 + this._displacementFrac) * this._maxDisplacement;
+        // start drawing barplots, and the first barplot layer. (It's possible
+        // for this._barplotPanel.distBtwnTreeAndBarplots to be 0, in which
+        // case there isn't a gap -- this looks kinda bad if node circles are
+        // drawn because the node circle of the tip(s) at this max displacement
+        // are partially covered by the barplots -- hence why this isn't the
+        // default).
+        var maxD = this._maxDisplacement +
+            (this._barplotPanel.distBtwnTreeAndBarplots * this._barplotUnit);
 
         // As we iterate through the layers, we'll store the "previous layer
         // max D" as a separate variable. This will help us easily work with

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -243,7 +243,7 @@ define([
          * between the first barplot layer and the closest-to-root point.
          * @private
          */
-        this._displacementFrac = 0.1;
+        this._displacementFrac = 0.05;
 
         /**
          * @type {Number}
@@ -1498,7 +1498,7 @@ define([
         // Add on a gap between the closest-to-the-root point at which we can
         // start drawing barplots, and the first barplot layer. This could be
         // made into a barplot-panel-level configurable thing if desired.
-        // Defaults to 1.1 * max displacement. If we used a 1.0 term instead,
+        // Defaults to 1.05 * max displacement. If we used a 1.0 term instead,
         // then barplots would start immediately at the max displacement (this
         // looks kinda bad because the node circle of the tip(s) at this max
         // displacement are partially covered by the barplots, so we don't do

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -1148,7 +1148,6 @@ define([
 
     Empress.prototype.changeBorderGap = function (width) {
         this._displacementFrac = width / 100;
-        console.log(this._maxDisplacement);
     };
 
     /**

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -241,6 +241,7 @@ define([
          * @type {Number}
          * Determines the fraction of _maxDisplacement to use as the gap
          * between the first barplot layer and the closest-to-root point.
+         * @private
          */
         this._displacementFrac = 0.1;
 
@@ -1146,10 +1147,6 @@ define([
         this._addTriangleCoords(coords, corners, color);
     };
 
-    Empress.prototype.changeBorderGap = function (width) {
-        this._displacementFrac = width / 100;
-    };
-
     /**
      * Thickens the colored branches of the tree.
      *
@@ -1501,12 +1498,11 @@ define([
         // Add on a gap between the closest-to-the-root point at which we can
         // start drawing barplots, and the first barplot layer. This could be
         // made into a barplot-panel-level configurable thing if desired.
-        // Currently, the 1.1 term here means that the barplots start at the
-        // max displacement plus 1/10th of the max displacement. If we used
-        // a 1.0 term instead, then barplots would start immediately at the max
-        // displacement (this looks kinda bad because the node circle of the
-        // tip(s) at this max displacement are partially covered by the
-        // barplots, so we don't do that).
+        // Defaults to 1.1 * max displacement. If we used a 1.0 term instead,
+        // then barplots would start immediately at the max displacement (this
+        // looks kinda bad because the node circle of the tip(s) at this max
+        // displacement are partially covered by the barplots, so we don't do
+        // that).
         var maxD = (1 + this._displacementFrac) * this._maxDisplacement;
 
         // As we iterate through the layers, we'll store the "previous layer

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -1494,8 +1494,9 @@ define([
         // drawn because the node circle of the tip(s) at this max displacement
         // are partially covered by the barplots -- hence why this isn't the
         // default).
-        var maxD = this._maxDisplacement +
-            (this._barplotPanel.distBtwnTreeAndBarplots * this._barplotUnit);
+        var maxD =
+            this._maxDisplacement +
+            this._barplotPanel.distBtwnTreeAndBarplots * this._barplotUnit;
 
         // As we iterate through the layers, we'll store the "previous layer
         // max D" as a separate variable. This will help us easily work with

--- a/empress/support_files/templates/side-panel.html
+++ b/empress/support_files/templates/side-panel.html
@@ -222,7 +222,7 @@
     </div>
     <div id="barplot-border-content" class="hidden">
       <p>
-        <label for="barplot-custom-gap">Separation length</label>
+        <label for="barplot-custom-gap">Distance between tree and barplots</label>
         <input id="barplot-custom-gap" type="number" class="empress-input">
       </p>
       <p>

--- a/empress/support_files/templates/side-panel.html
+++ b/empress/support_files/templates/side-panel.html
@@ -222,6 +222,10 @@
     </div>
     <div id="barplot-border-content" class="hidden">
       <p>
+        <label for="barplot-custom-gap">Separation length</label>
+        <input id="barplot-custom-gap" type="number" class="empress-input">
+      </p>
+      <p>
         <label for="barplot-border-chk">Add a border around barplot layers?</label>
         <input id="barplot-border-chk" type="checkbox" class="empress-input">
       </p>

--- a/tests/index.html
+++ b/tests/index.html
@@ -44,6 +44,10 @@
     </div>
     <div id="barplot-border-content" class="hidden">
       <p>
+        <label for="barplot-custom-gap">Distance between tree and barplots</label>
+        <input id="barplot-custom-gap" type="number" class="empress-input">
+      </p>
+      <p>
         <label for="barplot-border-chk">Add a border around barplot layers?</label>
         <input id="barplot-border-chk" type="checkbox" class="empress-input">
       </p>


### PR DESCRIPTION
Closes #453 

Adds a new element to the side panel that allows users to manually set the distance between the tree and the first barplot layer. Currently works by specifying a percentage increase to `_maxDisplacement`. ~Default value is 10 (1 + 10% = 1.1) to keep with current default behavior.~ Default value changed to 5 as we decided to decrease the default gap.

OLD: `var maxD = 1.1 * this._maxDisplacement;`

NEW: `var maxD = (1 + this._displacementFrac) * this._maxDisplacement;`

~A new function `Empress.prototype.changeBorderGap` just divides the input value by 100. This can likely be rewritten to not use a whole function - depends on what people think looks more clean.~

## Current Status

- [x] Pick a better display name than `Separation length`
- [x] Update relevant documentation in `empress.js`
- [x] Disallow negative values

![gap_movie](https://user-images.githubusercontent.com/4030868/101989613-241b5080-3c67-11eb-9c81-419d4adef16e.gif)



