### PR TITLE
remove sort/binarysearch

### DIFF
--- a/empress/support_files/js/canvas-events.js
+++ b/empress/support_files/js/canvas-events.js
@@ -300,43 +300,44 @@ define(["underscore", "glMatrix", "SelectedNodeMenu"], function (
 
             // search ids array for all possible words
             var suggestId,
-                suggestionsAdded = 0,
-                i = _.findIndex(ids, compareQuery, true);
+                word,
+                i = 0,
+                suggestedWords = [];
 
-            // no match was found
-            if (i === -1) {
-                return;
-            }
-
-            for (i; i < ids.length && suggestionsAdded < 10; i++) {
-                var word = ids[i];
+            for (i; i < ids.length && suggestedWords.length < 10; i++) {
+                word = ids[i];
 
                 // if node id begins with user query, add it to suggestionMenu
-                if (compareQuery(word)) {
-                    // create a container to hold the text/click event for the
-                    // suggested id
-                    suggestId = document.createElement("DIV");
-                    suggestId.id = word;
-
-                    suggestId.innerHTML =
-                        "<strong>" + word.substr(0, query.length) + "</strong>";
-                    suggestId.innerHTML += word.substr(query.length);
-
-                    // add click event so user can select id from menu
-                    suggestId.addEventListener("mousedown", createClickEvent);
-
-                    // add suggested id to the suggstions menu
-                    suggestionMenu.appendChild(suggestId);
-                    suggestionsAdded += 1;
-                } else {
-                    break;
+                if (compareQuery(word) && !_.contains(suggestedWords, word)) {
+                    suggestedWords.push(word);
                 }
+            }
+
+            suggestedWords.sort(function (a, b) {
+                return a.localeCompare(b, "en", { sensitivity: "base" });
+            });
+            for (var suggestion in suggestedWords) {
+                // create a container to hold the text/click event for the
+                // suggested id
+                word = suggestedWords[suggestion];
+                suggestId = document.createElement("DIV");
+                suggestId.id = word;
+
+                suggestId.innerHTML =
+                    "<strong>" + word.substr(0, query.length) + "</strong>";
+                suggestId.innerHTML += word.substr(query.length);
+
+                // add click event so user can select id from menu
+                suggestId.addEventListener("mousedown", createClickEvent);
+
+                // add suggested id to the suggstions menu
+                suggestionMenu.appendChild(suggestId);
             }
 
             // not all node ids were listed in the autofill box
             // create an ellipse autofill (...) to let users know there are
             // more possible options
-            if (i < ids.length && compareQuery(ids[i])) {
+            if (i < ids.length) {
                 suggestId = document.createElement("DIV");
 
                 suggestId.innerHTML = "<strong>...</strong>";

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -464,12 +464,6 @@ define([
         // Don't include nodes with the name null (i.e. nodes without a
         // specified name in the Newick file) in the auto-complete.
         nodeNames = nodeNames.filter((n) => n !== null);
-
-        // Sort node names case insensitively
-        nodeNames.sort(function (a, b) {
-            return a.localeCompare(b, "en", { sensitivity: "base" });
-        });
-        nodeNames = _.uniq(nodeNames);
         this._events.autocomplete(nodeNames);
 
         this.getLayoutInfo();


### PR DESCRIPTION
This addresses #462.

Here I removed the sorting of node names/filtering non-uniq names in order to speed up the load time for larger trees. In addition, I know perform a basic linear search when filling the name suggestion menu.