### PR TITLE
make _to_dict() public

### DIFF
--- a/empress/core.py
+++ b/empress/core.py
@@ -278,15 +278,19 @@ class Empress():
         main_template = self._get_template()
 
         # _process_data does a lot of munging to the coordinates data and
-        # _to_dict puts the data into a dictionary-like object for consumption
-        data = self._to_dict()
+        # to_dict puts the data into a dictionary-like object for consumption
+        data = self.to_dict()
 
         plot = main_template.render(data)
 
         return plot
 
-    def _to_dict(self):
+    def to_dict(self):
         """Convert processed data into a dictionary
+
+        Warning: the object returned by to_dict will contain references to
+        internal variables. Exercise caution if modifying the value of objects
+        returned by to_dict.
 
         Returns
         -------

--- a/tests/python/test_core.py
+++ b/tests/python/test_core.py
@@ -297,7 +297,7 @@ class TestCore(unittest.TestCase):
         viz = Empress(self.tree, self.table, self.sample_metadata,
                       shear_to_table=False)
 
-        obs = viz._to_dict()
+        obs = viz.to_dict()
         dict_a_cp = copy.deepcopy(DICT_A)
 
         # NOTE: Uncomment the following two lines of code to write the current
@@ -315,7 +315,7 @@ class TestCore(unittest.TestCase):
             self.tree, self.table, self.sample_metadata, self.feature_metadata,
             shear_to_table=False
         )
-        obs = viz._to_dict()
+        obs = viz.to_dict()
         dict_a_with_fm = copy.deepcopy(DICT_A)
         dict_a_with_fm["compressed_tip_metadata"] = {1: ["asdf", "qwer"]}
         dict_a_with_fm["compressed_int_metadata"] = {8: ["ghjk", "tyui"]}
@@ -333,7 +333,7 @@ class TestCore(unittest.TestCase):
         viz = Empress(self.tree, self.table, nan_sample_metadata,
                       nan_feature_metadata,
                       shear_to_table=False)
-        obs = viz._to_dict()
+        obs = viz.to_dict()
         dict_a_nan = copy.deepcopy(DICT_A)
 
         # [1][3] corresponds to Sample2, Metadata4
@@ -355,7 +355,7 @@ class TestCore(unittest.TestCase):
                       ordination=self.pcoa,
                       shear_to_table=False,
                       filter_extra_samples=True)
-        obs = viz._to_dict()
+        obs = viz.to_dict()
 
         self.assertEqual(viz._emperor.width, '50vw')
         self.assertEqual(viz._emperor.height, '100vh; float: right')
@@ -418,7 +418,7 @@ class TestCore(unittest.TestCase):
         dict_a_cp = copy.deepcopy(DICT_A)
         self._clear_copied_dict_a(dict_a_cp)
 
-        obs = viz._to_dict()
+        obs = viz.to_dict()
         self.assertEqual(obs, dict_a_cp)
 
     def test_to_dict_tree_plot_with_feature_metadata(self):
@@ -432,7 +432,7 @@ class TestCore(unittest.TestCase):
         dict_a_cp["compressed_int_metadata"] = {8: ["ghjk", "tyui"]}
         dict_a_cp["feature_metadata_columns"] = ["fmdcol1", "fmdcol2"]
 
-        obs = viz._to_dict()
+        obs = viz.to_dict()
         self.assertEqual(obs, dict_a_cp)
 
     def test_shear_tree_to_table(self):


### PR DESCRIPTION
In response to #470.

Rather than adding a parameter to return a copied version of the empress dictionary object, I decided to provided a warning in the doc string stating that to_dict returns references to internal objects. As @gwarmstrong mentioned in #470, its seems kind of wasteful to copy the object and since python does not technically have private variables I decided to simply return the dictionary object as is.