### PR TITLE
[DON'T MERGE THIS PLS] Include ancestor information in processed taxonomy feature metadata

### DIFF
--- a/empress/taxonomy_utils.py
+++ b/empress/taxonomy_utils.py
@@ -125,6 +125,14 @@ def split_taxonomy(feature_metadata):
                 ),
                 TaxonomyWarning
             )
+        else:
+            # Solve #473 -- add ancestor taxonomy strings
+            # (producing stuff like "k__Bacteria; p__Firmicutes; c__Bacilli"
+            # for class-level taxonomy levels).
+            # This disambiguates things like "s__" or "Unspecified" in the UI,
+            # at the cost of increasing metadata size.
+            for t in range(1, len(tax_levels.columns)):
+                tax_levels[t] = tax_levels[t - 1] + "; " + tax_levels[t]
 
         # Our use of expand=True means that tax_levels will be a DataFrame with
         # the same index as feature_metadata but with one column for each

--- a/tests/python/test_taxonomy_utils.py
+++ b/tests/python/test_taxonomy_utils.py
@@ -62,12 +62,12 @@ class TestTaxonomyUtils(unittest.TestCase):
             split_fm.loc["f1"],
             pd.Series({
                 "Level 1": "k__Bacteria",
-                "Level 2": "p__Bacteroidetes",
-                "Level 3": "c__Bacteroidia",
-                "Level 4": "o__Bacteroidales",
-                "Level 5": "f__Bacteroidaceae",
-                "Level 6": "g__Bacteroides",
-                "Level 7": "s__",
+                "Level 2": "k__Bacteria; p__Bacteroidetes",
+                "Level 3": "k__Bacteria; p__Bacteroidetes; c__Bacteroidia",
+                "Level 4": "k__Bacteria; p__Bacteroidetes; c__Bacteroidia; o__Bacteroidales",
+                "Level 5": "k__Bacteria; p__Bacteroidetes; c__Bacteroidia; o__Bacteroidales; f__Bacteroidaceae",
+                "Level 6": "k__Bacteria; p__Bacteroidetes; c__Bacteroidia; o__Bacteroidales; f__Bacteroidaceae; g__Bacteroides",
+                "Level 7": "k__Bacteria; p__Bacteroidetes; c__Bacteroidia; o__Bacteroidales; f__Bacteroidaceae; g__Bacteroides; s__",
                 "Confidence": 0.95
             }, name="f1")
         )
@@ -75,12 +75,12 @@ class TestTaxonomyUtils(unittest.TestCase):
             split_fm.loc["f2"],
             pd.Series({
                 "Level 1": "k__Bacteria",
-                "Level 2": "p__Proteobacteria",
-                "Level 3": "c__Gammaproteobacteria",
-                "Level 4": "o__Pasteurellales",
-                "Level 5": "f__Pasteurellaceae",
-                "Level 6": "g__",
-                "Level 7": "s__",
+                "Level 2": "k__Bacteria; p__Proteobacteria",
+                "Level 3": "k__Bacteria; p__Proteobacteria; c__Gammaproteobacteria",
+                "Level 4": "k__Bacteria; p__Proteobacteria; c__Gammaproteobacteria; o__Pasteurellales",
+                "Level 5": "k__Bacteria; p__Proteobacteria; c__Gammaproteobacteria; o__Pasteurellales; f__Pasteurellaceae",
+                "Level 6": "k__Bacteria; p__Proteobacteria; c__Gammaproteobacteria; o__Pasteurellales; f__Pasteurellaceae; g__",
+                "Level 7": "k__Bacteria; p__Proteobacteria; c__Gammaproteobacteria; o__Pasteurellales; f__Pasteurellaceae; g__; s__",
                 "Confidence": 0.8
             }, name="f2")
         )
@@ -88,12 +88,12 @@ class TestTaxonomyUtils(unittest.TestCase):
             split_fm.loc["f3"],
             pd.Series({
                 "Level 1": "k__Bacteria",
-                "Level 2": "p__Bacteroidetes",
-                "Level 3": "c__Bacteroidia",
-                "Level 4": "o__Bacteroidales",
-                "Level 5": "f__Bacteroidaceae",
-                "Level 6": "g__Bacteroides",
-                "Level 7": "s__uniformis",
+                "Level 2": "k__Bacteria; p__Bacteroidetes",
+                "Level 3": "k__Bacteria; p__Bacteroidetes; c__Bacteroidia",
+                "Level 4": "k__Bacteria; p__Bacteroidetes; c__Bacteroidia; o__Bacteroidales",
+                "Level 5": "k__Bacteria; p__Bacteroidetes; c__Bacteroidia; o__Bacteroidales; f__Bacteroidaceae",
+                "Level 6": "k__Bacteria; p__Bacteroidetes; c__Bacteroidia; o__Bacteroidales; f__Bacteroidaceae; g__Bacteroides",
+                "Level 7": "k__Bacteria; p__Bacteroidetes; c__Bacteroidia; o__Bacteroidales; f__Bacteroidaceae; g__Bacteroides; s__uniformis",
                 "Confidence": 0
             }, name="f3")
         )
@@ -101,12 +101,12 @@ class TestTaxonomyUtils(unittest.TestCase):
             split_fm.loc["f4"],
             pd.Series({
                 "Level 1": "k__Bacteria",
-                "Level 2": "p__Firmicutes",
-                "Level 3": "c__Bacilli",
-                "Level 4": "Unspecified",
-                "Level 5": "Unspecified",
-                "Level 6": "Unspecified",
-                "Level 7": "Unspecified",
+                "Level 2": "k__Bacteria; p__Firmicutes",
+                "Level 3": "k__Bacteria; p__Firmicutes; c__Bacilli",
+                "Level 4": "k__Bacteria; p__Firmicutes; c__Bacilli; Unspecified",
+                "Level 5": "k__Bacteria; p__Firmicutes; c__Bacilli; Unspecified; Unspecified",
+                "Level 6": "k__Bacteria; p__Firmicutes; c__Bacilli; Unspecified; Unspecified; Unspecified",
+                "Level 7": "k__Bacteria; p__Firmicutes; c__Bacilli; Unspecified; Unspecified; Unspecified; Unspecified",
                 "Confidence": 1
             }, name="f4")
         )
@@ -181,8 +181,8 @@ class TestTaxonomyUtils(unittest.TestCase):
             split_fm.loc["f1"],
             pd.Series({
                 "Level 1": "birds aren't real",
-                "Level 2": "Unspecified",
-                "Level 3": "Unspecified",
+                "Level 2": "birds aren't real; Unspecified",
+                "Level 3": "birds aren't real; Unspecified; Unspecified",
                 "Confidence": 0.95
             }, name="f1")
         )
@@ -190,8 +190,8 @@ class TestTaxonomyUtils(unittest.TestCase):
             split_fm.loc["f2"],
             pd.Series({
                 "Level 1": "theyve been drones",
-                "Level 2": "Unspecified",
-                "Level 3": "Unspecified",
+                "Level 2": "theyve been drones; Unspecified",
+                "Level 3": "theyve been drones; Unspecified; Unspecified",
                 "Confidence": 0.8
             }, name="f2")
         )
@@ -199,8 +199,8 @@ class TestTaxonomyUtils(unittest.TestCase):
             split_fm.loc["f3"],
             pd.Series({
                 "Level 1": "all along :O",
-                "Level 2": "Unspecified",
-                "Level 3": "Unspecified",
+                "Level 2": "all along :O; Unspecified",
+                "Level 3": "all along :O; Unspecified; Unspecified",
                 "Confidence": 0
             }, name="f3")
         )
@@ -208,8 +208,8 @@ class TestTaxonomyUtils(unittest.TestCase):
             split_fm.loc["f4"],
             pd.Series({
                 "Level 1": "k__Bacteria",
-                "Level 2": "p__Firmicutes",
-                "Level 3": "c__Bacilli",
+                "Level 2": "k__Bacteria; p__Firmicutes",
+                "Level 3": "k__Bacteria; p__Firmicutes; c__Bacilli",
                 "Confidence": 1
             }, name="f4")
         )
@@ -293,12 +293,12 @@ class TestTaxonomyUtils(unittest.TestCase):
             split_fm.loc["f0"],
             pd.Series({
                 "Level 1": "D_0__Bacteria",
-                "Level 2": "D_1__Gemmatimonadetes",
-                "Level 3": "D_2__Gemmatimonadetes",
-                "Level 4": "D_3__Gemmatimonadales",
-                "Level 5": "D_4__Gemmatimonadaceae",
-                "Level 6": "D_5__Gemmatimonas",
-                "Level 7": "D_6__uncultured bacterium",
+                "Level 2": "D_0__Bacteria; D_1__Gemmatimonadetes",
+                "Level 3": "D_0__Bacteria; D_1__Gemmatimonadetes; D_2__Gemmatimonadetes",
+                "Level 4": "D_0__Bacteria; D_1__Gemmatimonadetes; D_2__Gemmatimonadetes; D_3__Gemmatimonadales",
+                "Level 5": "D_0__Bacteria; D_1__Gemmatimonadetes; D_2__Gemmatimonadetes; D_3__Gemmatimonadales; D_4__Gemmatimonadaceae",
+                "Level 6": "D_0__Bacteria; D_1__Gemmatimonadetes; D_2__Gemmatimonadetes; D_3__Gemmatimonadales; D_4__Gemmatimonadaceae; D_5__Gemmatimonas",
+                "Level 7": "D_0__Bacteria; D_1__Gemmatimonadetes; D_2__Gemmatimonadetes; D_3__Gemmatimonadales; D_4__Gemmatimonadaceae; D_5__Gemmatimonas; D_6__uncultured bacterium",
             }, name="f0")
         )
 

--- a/tests/python/test_taxonomy_utils.py
+++ b/tests/python/test_taxonomy_utils.py
@@ -64,10 +64,22 @@ class TestTaxonomyUtils(unittest.TestCase):
                 "Level 1": "k__Bacteria",
                 "Level 2": "k__Bacteria; p__Bacteroidetes",
                 "Level 3": "k__Bacteria; p__Bacteroidetes; c__Bacteroidia",
-                "Level 4": "k__Bacteria; p__Bacteroidetes; c__Bacteroidia; o__Bacteroidales",
-                "Level 5": "k__Bacteria; p__Bacteroidetes; c__Bacteroidia; o__Bacteroidales; f__Bacteroidaceae",
-                "Level 6": "k__Bacteria; p__Bacteroidetes; c__Bacteroidia; o__Bacteroidales; f__Bacteroidaceae; g__Bacteroides",
-                "Level 7": "k__Bacteria; p__Bacteroidetes; c__Bacteroidia; o__Bacteroidales; f__Bacteroidaceae; g__Bacteroides; s__",
+                "Level 4": (
+                    "k__Bacteria; p__Bacteroidetes; c__Bacteroidia; "
+                    "o__Bacteroidales"
+                ),
+                "Level 5": (
+                    "k__Bacteria; p__Bacteroidetes; c__Bacteroidia; "
+                    "o__Bacteroidales; f__Bacteroidaceae"
+                ),
+                "Level 6": (
+                    "k__Bacteria; p__Bacteroidetes; c__Bacteroidia; "
+                    "o__Bacteroidales; f__Bacteroidaceae; g__Bacteroides"
+                ),
+                "Level 7": (
+                    "k__Bacteria; p__Bacteroidetes; c__Bacteroidia; "
+                    "o__Bacteroidales; f__Bacteroidaceae; g__Bacteroides; s__"
+                ),
                 "Confidence": 0.95
             }, name="f1")
         )
@@ -76,11 +88,25 @@ class TestTaxonomyUtils(unittest.TestCase):
             pd.Series({
                 "Level 1": "k__Bacteria",
                 "Level 2": "k__Bacteria; p__Proteobacteria",
-                "Level 3": "k__Bacteria; p__Proteobacteria; c__Gammaproteobacteria",
-                "Level 4": "k__Bacteria; p__Proteobacteria; c__Gammaproteobacteria; o__Pasteurellales",
-                "Level 5": "k__Bacteria; p__Proteobacteria; c__Gammaproteobacteria; o__Pasteurellales; f__Pasteurellaceae",
-                "Level 6": "k__Bacteria; p__Proteobacteria; c__Gammaproteobacteria; o__Pasteurellales; f__Pasteurellaceae; g__",
-                "Level 7": "k__Bacteria; p__Proteobacteria; c__Gammaproteobacteria; o__Pasteurellales; f__Pasteurellaceae; g__; s__",
+                "Level 3": (
+                    "k__Bacteria; p__Proteobacteria; c__Gammaproteobacteria"
+                ),
+                "Level 4": (
+                    "k__Bacteria; p__Proteobacteria; c__Gammaproteobacteria; "
+                    "o__Pasteurellales"
+                ),
+                "Level 5": (
+                    "k__Bacteria; p__Proteobacteria; c__Gammaproteobacteria; "
+                    "o__Pasteurellales; f__Pasteurellaceae"
+                ),
+                "Level 6": (
+                    "k__Bacteria; p__Proteobacteria; c__Gammaproteobacteria; "
+                    "o__Pasteurellales; f__Pasteurellaceae; g__"
+                ),
+                "Level 7": (
+                    "k__Bacteria; p__Proteobacteria; c__Gammaproteobacteria; "
+                    "o__Pasteurellales; f__Pasteurellaceae; g__; s__"
+                ),
                 "Confidence": 0.8
             }, name="f2")
         )
@@ -90,10 +116,23 @@ class TestTaxonomyUtils(unittest.TestCase):
                 "Level 1": "k__Bacteria",
                 "Level 2": "k__Bacteria; p__Bacteroidetes",
                 "Level 3": "k__Bacteria; p__Bacteroidetes; c__Bacteroidia",
-                "Level 4": "k__Bacteria; p__Bacteroidetes; c__Bacteroidia; o__Bacteroidales",
-                "Level 5": "k__Bacteria; p__Bacteroidetes; c__Bacteroidia; o__Bacteroidales; f__Bacteroidaceae",
-                "Level 6": "k__Bacteria; p__Bacteroidetes; c__Bacteroidia; o__Bacteroidales; f__Bacteroidaceae; g__Bacteroides",
-                "Level 7": "k__Bacteria; p__Bacteroidetes; c__Bacteroidia; o__Bacteroidales; f__Bacteroidaceae; g__Bacteroides; s__uniformis",
+                "Level 4": (
+                    "k__Bacteria; p__Bacteroidetes; c__Bacteroidia; "
+                    "o__Bacteroidales"
+                ),
+                "Level 5": (
+                    "k__Bacteria; p__Bacteroidetes; c__Bacteroidia; "
+                    "o__Bacteroidales; f__Bacteroidaceae"
+                ),
+                "Level 6": (
+                    "k__Bacteria; p__Bacteroidetes; c__Bacteroidia; "
+                    "o__Bacteroidales; f__Bacteroidaceae; g__Bacteroides"
+                ),
+                "Level 7": (
+                    "k__Bacteria; p__Bacteroidetes; c__Bacteroidia; "
+                    "o__Bacteroidales; f__Bacteroidaceae; g__Bacteroides; "
+                    "s__uniformis"
+                ),
                 "Confidence": 0
             }, name="f3")
         )
@@ -103,10 +142,21 @@ class TestTaxonomyUtils(unittest.TestCase):
                 "Level 1": "k__Bacteria",
                 "Level 2": "k__Bacteria; p__Firmicutes",
                 "Level 3": "k__Bacteria; p__Firmicutes; c__Bacilli",
-                "Level 4": "k__Bacteria; p__Firmicutes; c__Bacilli; Unspecified",
-                "Level 5": "k__Bacteria; p__Firmicutes; c__Bacilli; Unspecified; Unspecified",
-                "Level 6": "k__Bacteria; p__Firmicutes; c__Bacilli; Unspecified; Unspecified; Unspecified",
-                "Level 7": "k__Bacteria; p__Firmicutes; c__Bacilli; Unspecified; Unspecified; Unspecified; Unspecified",
+                "Level 4": (
+                    "k__Bacteria; p__Firmicutes; c__Bacilli; Unspecified"
+                ),
+                "Level 5": (
+                    "k__Bacteria; p__Firmicutes; c__Bacilli; Unspecified; "
+                    "Unspecified"
+                ),
+                "Level 6": (
+                    "k__Bacteria; p__Firmicutes; c__Bacilli; Unspecified; "
+                    "Unspecified; Unspecified"
+                ),
+                "Level 7": (
+                    "k__Bacteria; p__Firmicutes; c__Bacilli; Unspecified; "
+                    "Unspecified; Unspecified; Unspecified"
+                ),
                 "Confidence": 1
             }, name="f4")
         )
@@ -294,11 +344,30 @@ class TestTaxonomyUtils(unittest.TestCase):
             pd.Series({
                 "Level 1": "D_0__Bacteria",
                 "Level 2": "D_0__Bacteria; D_1__Gemmatimonadetes",
-                "Level 3": "D_0__Bacteria; D_1__Gemmatimonadetes; D_2__Gemmatimonadetes",
-                "Level 4": "D_0__Bacteria; D_1__Gemmatimonadetes; D_2__Gemmatimonadetes; D_3__Gemmatimonadales",
-                "Level 5": "D_0__Bacteria; D_1__Gemmatimonadetes; D_2__Gemmatimonadetes; D_3__Gemmatimonadales; D_4__Gemmatimonadaceae",
-                "Level 6": "D_0__Bacteria; D_1__Gemmatimonadetes; D_2__Gemmatimonadetes; D_3__Gemmatimonadales; D_4__Gemmatimonadaceae; D_5__Gemmatimonas",
-                "Level 7": "D_0__Bacteria; D_1__Gemmatimonadetes; D_2__Gemmatimonadetes; D_3__Gemmatimonadales; D_4__Gemmatimonadaceae; D_5__Gemmatimonas; D_6__uncultured bacterium",
+                "Level 3": (
+                    "D_0__Bacteria; D_1__Gemmatimonadetes; "
+                    "D_2__Gemmatimonadetes"
+                ),
+                "Level 4": (
+                    "D_0__Bacteria; D_1__Gemmatimonadetes; "
+                    "D_2__Gemmatimonadetes; D_3__Gemmatimonadales"
+                ),
+                "Level 5": (
+                    "D_0__Bacteria; D_1__Gemmatimonadetes; "
+                    "D_2__Gemmatimonadetes; D_3__Gemmatimonadales; "
+                    "D_4__Gemmatimonadaceae"
+                ),
+                "Level 6": (
+                    "D_0__Bacteria; D_1__Gemmatimonadetes; "
+                    "D_2__Gemmatimonadetes; D_3__Gemmatimonadales; "
+                    "D_4__Gemmatimonadaceae; D_5__Gemmatimonas"
+                ),
+                "Level 7": (
+                    "D_0__Bacteria; D_1__Gemmatimonadetes; "
+                    "D_2__Gemmatimonadetes; D_3__Gemmatimonadales; "
+                    "D_4__Gemmatimonadaceae; D_5__Gemmatimonas; "
+                    "D_6__uncultured bacterium"
+                ),
             }, name="f0")
         )
 


### PR DESCRIPTION
Closes #473. And closes #422, I guess!

Rather than representing a species-level "classification" as something like `"s__"`, we now represent it in the feature metadata as something like `"k__Bacteria; p__Bacteroidetes; c__Bacteroidia; o__Bacteroidales; f__Bacteroidaceae; g__Bacteroides; s__"`.

This has a few nice side effects, including:

1. Stuff like `s__`, `g__`, `Unspecified`, etc. no longer form blobs of highly-common values when coloring the tree by taxonomy at a given level. Previously, coloring by level 6 or 7 using the default `Classic QIIME Colors` color map would show a ton of ugly red blobs -- this was because the first value alphabetically was `g__` / `s__` / etc., which was getting assigned red. See, for example, the outer layer (Level 7 in the Moving Pictures dataset) in the following screenshots, and how the red blobs go away due to this change:

    __Taxonomy levels 1 through 7 (kingdom through species), moving pictures dataset, before:__
    ![lessfancy](https://user-images.githubusercontent.com/4177727/107112160-487c4f00-680a-11eb-8fc5-a0f4d7d02a47.png)

    __Taxonomy levels 1 through 7 (kingdom through species), moving pictures dataset, after:__
    ![fancy](https://user-images.githubusercontent.com/4177727/107112179-7366a300-680a-11eb-934b-dd088981cc67.png)

2. Propagation (when coloring the tree itself by taxonomy; see #473 for details) is now limited to values of a taxonomy field that share ancestry. So now we don't have the problem of e.g. a bunch of unrelated `s__` values being merged together in the feature metadata coloring for level 7.
    
    *It is still possible for propagation to be done on `s__` (or on `Unspecified`, or other weird taxonomy values)*, but only between values with the same ancestry, if that makes sense. So we no longer consider `k__Bacteria; p__Bacteroidetes; c__Bacteroidia; o__Bacteroidales; f__Bacteroidaceae; g__Bacteroides; s__` to be equal to `k__Archaea; p__somephylum; c__idk; o__; f__; g__; s__`, although both are equal to themselves.


    __Coloring the tree by level 7 (species), moving pictures dataset, before:__
    ![before7](https://user-images.githubusercontent.com/4177727/107112287-5aaabd00-680b-11eb-9e20-f11ba43397ff.png)

    __Coloring the tree by level 7 (species), moving pictures dataset, after:__
    ![after7](https://user-images.githubusercontent.com/4177727/107112288-5f6f7100-680b-11eb-95cf-902a43b0a685.png)

## Caveats
This does inflate the size of the feature metadata stored in an EMPress visualization, probably by a decent amount. I haven't done thorough benchmarking yet, but I'd imagine it is pretty substantial.

This also arguably makes part of the UI look inelegant (see for example the legend in the final screenshot above -- users will have to scroll through the legend to see things like species names).

We could _potentially_ solve at least the size problem by not changing the way we store taxonomy feature metadata, and only considering ancestor info in the JS code when assigning colors / doing propagation or whatever, but that seems to me like it might be a headache to implement. However, personally: I think the benefits of this PR outweigh the downsides, and that future changes like #337 and #371 (PR for the latter coming soon :tm:) will offset these problems nicely.