### PR TITLE
Fixes error when no feature metadata file is provided

### DIFF
--- a/empress/core.py
+++ b/empress/core.py
@@ -164,7 +164,10 @@ class Empress():
 
                 # if there are no matches set to None so Emperor can ignore
                 # the feature metadata
-                feature_metadata = pd.concat([self.tip_md, self.int_md])
+                if (self.tip_md is None) and (self.int_md is None): 
+                    feature_metadata = pd.DataFrame()
+                else: 
+                    feature_metadata = pd.concat([self.tip_md, self.int_md])
                 arrows = self.ordination.features.index
                 if (feature_metadata.index.intersection(arrows).empty or
                    feature_metadata.empty):

--- a/empress/core.py
+++ b/empress/core.py
@@ -164,9 +164,9 @@ class Empress():
 
                 # if there are no matches set to None so Emperor can ignore
                 # the feature metadata
-                if self.tip_md is None and self.int_md is None: 
+                if self.tip_md is None and self.int_md is None:
                     feature_metadata = pd.DataFrame()
-                else: 
+                else:
                     feature_metadata = pd.concat([self.tip_md, self.int_md])
                 arrows = self.ordination.features.index
                 if (feature_metadata.index.intersection(arrows).empty or

--- a/empress/core.py
+++ b/empress/core.py
@@ -164,7 +164,7 @@ class Empress():
 
                 # if there are no matches set to None so Emperor can ignore
                 # the feature metadata
-                if (self.tip_md is None) and (self.int_md is None): 
+                if self.tip_md is None and self.int_md is None: 
                     feature_metadata = pd.DataFrame()
                 else: 
                     feature_metadata = pd.concat([self.tip_md, self.int_md])

--- a/tests/python/test_core.py
+++ b/tests/python/test_core.py
@@ -244,12 +244,10 @@ class TestCore(unittest.TestCase):
         self.assertTrue(isinstance(viz._emperor, Emperor))
 
     def test_init_with_ordination_features(self):
+        '''Check that empress does not break when ordination has features
+        but empress itself does not.'''
         viz = Empress(self.tree, self.table, self.sample_metadata,
-                      ordination=self.pcoa, shear_to_table=False)
-        '''check that empress does not break when ordination has features
-        but empress itself does not'''
-        viz.ordination.features = self.feature_metadata
-        self.assertIsNone(viz.features)
+                      ordination=self.biplot, shear_to_table=False)
 
     def test_init_with_ordination_empty_samples_in_pcoa(self):
         def make_bad(v, i, m):

--- a/tests/python/test_core.py
+++ b/tests/python/test_core.py
@@ -246,7 +246,6 @@ class TestCore(unittest.TestCase):
     def test_init_with_ordination_features(self):
         viz = Empress(self.tree, self.table, self.sample_metadata,
                       ordination=self.pcoa, shear_to_table=False)
-        
         '''check that empress does not break when ordination has features
         but empress itself does not'''
         viz.ordination.features = self.feature_metadata

--- a/tests/python/test_core.py
+++ b/tests/python/test_core.py
@@ -249,7 +249,7 @@ class TestCore(unittest.TestCase):
         '''check that empress does not break when ordination has features
         but empress itself does not'''
         viz.ordination.features = self.feature_metadata
-        self.assertEqual(viz.features, pd.DataFrame())
+        self.assertTrue(viz.features.empty)
 
     def test_init_with_ordination_empty_samples_in_pcoa(self):
         def make_bad(v, i, m):

--- a/tests/python/test_core.py
+++ b/tests/python/test_core.py
@@ -248,6 +248,7 @@ class TestCore(unittest.TestCase):
         but empress itself does not.'''
         viz = Empress(self.tree, self.table, self.sample_metadata,
                       ordination=self.biplot, shear_to_table=False)
+        self.assertIsNone(viz.features)
 
     def test_init_with_ordination_empty_samples_in_pcoa(self):
         def make_bad(v, i, m):

--- a/tests/python/test_core.py
+++ b/tests/python/test_core.py
@@ -249,7 +249,7 @@ class TestCore(unittest.TestCase):
         '''check that empress does not break when ordination has features
         but empress itself does not'''
         viz.ordination.features = self.feature_metadata
-        self.assertTrue(viz.features.empty)
+        self.assertIsNone(viz.features)
 
     def test_init_with_ordination_empty_samples_in_pcoa(self):
         def make_bad(v, i, m):

--- a/tests/python/test_core.py
+++ b/tests/python/test_core.py
@@ -243,6 +243,15 @@ class TestCore(unittest.TestCase):
         # emperor is instantiated as needed but not yet setup
         self.assertTrue(isinstance(viz._emperor, Emperor))
 
+    def test_init_with_ordination_features(self):
+        viz = Empress(self.tree, self.table, self.sample_metadata,
+                      ordination=self.pcoa, shear_to_table=False)
+        
+        '''check that empress does not break when ordination has features
+        but empress itself does not'''
+        viz.ordination.features = self.feature_metadata
+        self.assertEqual(viz.feature_metadata, pd.DataFrame())
+
     def test_init_with_ordination_empty_samples_in_pcoa(self):
         def make_bad(v, i, m):
             if i in ['Sample2', 'Sample4']:

--- a/tests/python/test_core.py
+++ b/tests/python/test_core.py
@@ -250,7 +250,7 @@ class TestCore(unittest.TestCase):
         '''check that empress does not break when ordination has features
         but empress itself does not'''
         viz.ordination.features = self.feature_metadata
-        self.assertEqual(viz.feature_metadata, pd.DataFrame())
+        self.assertEqual(viz.features, pd.DataFrame())
 
     def test_init_with_ordination_empty_samples_in_pcoa(self):
         def make_bad(v, i, m):


### PR DESCRIPTION
When I previously ran empress without supplying a feature metadata file, I received the error "All objects passed were None." This occurs on line 167 when pandas attempts to concatenate two Nones. I added a line to check whether both self.tip_md and self.int_md are both None to avoid raising the error. 