### PR TITLE
Use ancestor information in taxonomy feature metadata (only computing ancestor info in the JS interface)

### DIFF
--- a/empress/core.py
+++ b/empress/core.py
@@ -185,7 +185,11 @@ class Empress():
                                  shear_to_feature_metadata):
 
         if self.is_community_plot:
-            self.table, self.samples, self.tip_md, self.int_md, self.tax_cols = match_inputs(
+            # Hack to unpack long tuples: https://stackoverflow.com/q/26036143
+            (
+                self.table, self.samples, self.tip_md, self.int_md,
+                self.tax_cols
+            ) = match_inputs(
                 self.tree, self.table, self.samples, self.features,
                 self.ordination, ignore_missing_samples, filter_extra_samples,
                 filter_missing_features
@@ -226,9 +230,9 @@ class Empress():
                         "the tree are present in the feature metadata."
                     )
                 self.tree = self.tree.shear(features)
-            self.tip_md, self.int_md, self.tax_cols = match_tree_and_feature_metadata(
-                self.tree, self.features
-            )
+            (
+                self.tip_md, self.int_md, self.tax_cols
+            ) = match_tree_and_feature_metadata(self.tree, self.features)
         validate_tree(self.tree)
 
     def copy_support_files(self, target=None):

--- a/empress/core.py
+++ b/empress/core.py
@@ -185,7 +185,7 @@ class Empress():
                                  shear_to_feature_metadata):
 
         if self.is_community_plot:
-            self.table, self.samples, self.tip_md, self.int_md = match_inputs(
+            self.table, self.samples, self.tip_md, self.int_md, self.tax_cols = match_inputs(
                 self.tree, self.table, self.samples, self.features,
                 self.ordination, ignore_missing_samples, filter_extra_samples,
                 filter_missing_features
@@ -226,7 +226,7 @@ class Empress():
                         "the tree are present in the feature metadata."
                     )
                 self.tree = self.tree.shear(features)
-            self.tip_md, self.int_md = match_tree_and_feature_metadata(
+            self.tip_md, self.int_md, self.tax_cols = match_tree_and_feature_metadata(
                 self.tree, self.features
             )
         validate_tree(self.tree)
@@ -364,6 +364,7 @@ class Empress():
             'compressed_sample_metadata': compressed_sm,
             # feature metadata
             'feature_metadata_columns': fm_cols,
+            'split_taxonomy_columns': self.tax_cols,
             'compressed_tip_metadata': compressed_tm,
             'compressed_int_metadata': compressed_im,
             # Emperor integration

--- a/empress/support_files/css/empress.css
+++ b/empress/support_files/css/empress.css
@@ -598,7 +598,7 @@ p.side-header button:hover,
 #legend-main {
     margin: 20px;
     min-width: 150px;
-    max-width: 40vh;
+    max-width: 33vw;
     min-height: 30px;
     max-height: 85vh;
     resize: both;

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -1925,18 +1925,15 @@ define([
                 // Assign this tip's bar a color
                 var color;
                 if (layer.colorByFM) {
-                    // We only need to try to see if this is a taxonomy column
-                    // for the color encodings -- since encoding a taxonomy col
-                    // as length should trigger an error, since taxonomy is
-                    // inherently not numeric (and anyway we insert ; characters
-                    // into the taxonomy values, so this should force errors when
-                    // trying to convert taxonomy values into numbers)
-                    var getValFromFM = this._getFMValRetrievalFunction(
+                    // Get a function that'll retrieve feature metadata from
+                    // this field for us. As of writing, only does anything
+                    // special for certain taxonomy columns.
+                    var getValFromColorFM = this._getFMValRetrievalFunction(
                         layer.colorByFMField
                     );
 
                     if (_.has(this._tipMetadata, node)) {
-                        fm = getValFromFM(this._tipMetadata[node]);
+                        fm = getValFromColorFM(this._tipMetadata[node]);
                         if (_.has(fm2color, fm)) {
                             color = fm2color[fm];
                         } else {
@@ -1959,8 +1956,19 @@ define([
                 // Assign this tip's bar a length
                 var length;
                 if (layer.scaleLengthByFM) {
+                    // Get a function that'll retrieve feature metadata from
+                    // this field for us. As of writing, this currently is
+                    // not especially useful for length scaling, since this
+                    // function only does something special for taxonomy
+                    // columns -- and those shouldn't be numeric. However,
+                    // using this function as the middle-man here ensures
+                    // consistency with how the other uses of feature metadata
+                    // work (in case we define further special cases later on).
+                    var getValFromLengthFM = this._getFMValRetrievalFunction(
+                        layer.scaleLengthByFMField
+                    );
                     if (_.has(this._tipMetadata, node)) {
-                        fm = this._tipMetadata[node][lengthFMIdx];
+                        fm = getValFromLengthFM(this._tipMetadata[node]);
                         if (_.has(fm2length, fm)) {
                             length = fm2length[fm];
                         } else {

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -1932,7 +1932,10 @@ define([
                     // into the taxonomy values, so this should force errors when
                     // trying to convert taxonomy values into numbers)
                     var getValFromFM;
-                    var taxIdx = _.indexOf(this._splitTaxonomyColumns, layer.colorByFMField);
+                    var taxIdx = _.indexOf(
+                        this._splitTaxonomyColumns,
+                        layer.colorByFMField
+                    );
                     if (taxIdx <= 0) {
                         getValFromFM = function (fmRow) {
                             return fmRow[colorFMIdx];
@@ -1942,14 +1945,18 @@ define([
                         for (var i = 0; i < taxIdx; i++) {
                             var currTaxCol = this._splitTaxonomyColumns[i];
                             var currTaxColFMIdx = _.indexOf(
-                                this._featureMetadataColumns, currTaxCol
+                                this._featureMetadataColumns,
+                                currTaxCol
                             );
                             ancestorFMIndices.push(currTaxColFMIdx);
                         }
                         ancestorFMIndices.push(colorFMIdx);
                         getValFromFM = function (fmRow) {
                             var totalFMVal = "";
-                            _.each(ancestorFMIndices, function (ancestorFMIdx, t) {
+                            _.each(ancestorFMIndices, function (
+                                ancestorFMIdx,
+                                t
+                            ) {
                                 if (t > 0) {
                                     totalFMVal += "; ";
                                 }
@@ -2291,7 +2298,8 @@ define([
             for (var i = 0; i < taxIdx; i++) {
                 var currTaxCol = this._splitTaxonomyColumns[i];
                 var currTaxColFMIdx = _.indexOf(
-                    this._featureMetadataColumns, currTaxCol
+                    this._featureMetadataColumns,
+                    currTaxCol
                 );
                 ancestorFMIndices.push(currTaxColFMIdx);
             }

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -40,6 +40,13 @@ define([
      *                      when generating an Empress visualization, this
      *                      parameter should be [] (and tipMetadata and
      *                      intMetadata should be {}s).
+     * @param {Array} splitTaxonomyColumns Columns of the feature metadata
+     *                                     corresponding to explicitly
+     *                                     specified levels of a taxonomy, if
+     *                                     available. Should be [] if not
+     *                                     applicable. Every value in this
+     *                                     Array must also be present in
+     *                                     featureMetadataColumns.
      * @param {Object} tipMetadata Feature metadata for tips in the tree.
      *                 Note: This should map tip names to an array of feature
      *                       metadata values. Each array should have the same
@@ -53,6 +60,7 @@ define([
         tree,
         biom,
         featureMetadataColumns,
+        splitTaxonomyColumns,
         tipMetadata,
         intMetadata,
         canvas
@@ -167,11 +175,21 @@ define([
         this.isCommunityPlot = !_.isNull(this._biom);
 
         /**
-         * @type{Array}
+         * @type {Array}
          * Feature metadata column names.
          * @private
          */
         this._featureMetadataColumns = featureMetadataColumns;
+
+        /**
+         * @type {Array}
+         * Taxonomy column names. Should be handled specially when coloring
+         * by these, or using them in feature metadata barplots -- see
+         * https://github.com/biocore/empress/issues/473 and
+         * https://github.com/biocore/empress/pull/482 for details/discussion.
+         * @private
+         */
+        this._splitTaxonomyColumns = splitTaxonomyColumns;
 
         /**
          * @type{Object}

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -1918,6 +1918,17 @@ define([
         } else {
             halfAngleRange = Math.PI / this._tree.numleaves();
         }
+        // NOTE that, for drawing a barplot layer representing a taxonomy
+        // column, we are essentially doing the work here of "reassembling"
+        // the ancestor taxonomy with the child taxonomy info twice -- once
+        // when we call this.getUniqueFeatureMetadataInfo() above, and again
+        // as we go through this loop and look at each tip (this is done for
+        // each tip by the "retrieval function" mentioned below).
+        //
+        // It would be ideal to use the mapping information returned by
+        // this.getUniqueFeatureMetadataInfo() to avoid having to repeat this
+        // work, although this would likely require restructuring the rest
+        // of this function -- might be too much work for its own good.
         for (node = 1; node < this._tree.size; node++) {
             if (this._tree.isleaf(this._tree.postorderselect(node))) {
                 var name = this.getNodeInfo(node, "name");

--- a/empress/support_files/templates/empress-template.html
+++ b/empress/support_files/templates/empress-template.html
@@ -138,6 +138,8 @@
 
         var fmCols = {{ feature_metadata_columns | tojson }};
 
+        var splitTaxonomyCols = {{ split_taxonomy_columns | tojson }};
+
         var canvas = document.getElementById('tree-surface');
 
         // NOTE: the contents of this line are validated in the python
@@ -161,6 +163,7 @@
             tree,
             biom,
             fmCols,
+            splitTaxonomyCols,
             {{ compressed_tip_metadata | tojson }},
             {{ compressed_int_metadata | tojson }},
             canvas

--- a/empress/tools.py
+++ b/empress/tools.py
@@ -143,7 +143,7 @@ def match_inputs(
     Returns
     -------
     (table, sample_metadata, tip_metadata, int_metadata, tax_columns):
-        (biom.Table, pd.DataFrame, pd.DataFrame / None, pd.DataFrame / None, list)
+        (biom.Table, pd.DataFrame, pd.DataFrame|None, pd.DataFrame|None, list)
         Versions of the input table, sample metadata, and feature metadata
         filtered such that:
             -The table only contains features also present as tips in the tree.
@@ -331,7 +331,9 @@ def match_inputs(
         feature_metadata
     )
 
-    return ff_table, sf_sample_metadata, tip_metadata, int_metadata, tax_columns
+    return (
+        ff_table, sf_sample_metadata, tip_metadata, int_metadata, tax_columns
+    )
 
 
 def shifting(bitlist, size=51):

--- a/empress/tools.py
+++ b/empress/tools.py
@@ -73,7 +73,7 @@ def match_tree_and_feature_metadata(bp_tree, feature_metadata=None):
         int_metadata = ts_feature_metadata.loc[fm_and_int_features]
 
         if len(tip_metadata.index) == 0 and len(int_metadata.index) == 0:
-            # Error condition 5 in match_inputs_community_plot()
+            # Error condition 5 in match_inputs()
             raise DataMatchingError(
                 "No features in the feature metadata are present in the tree, "
                 "either as tips or as internal nodes."
@@ -166,8 +166,10 @@ def match_inputs(
                metadata, AND ignore_missing_samples is False.
             5. The feature metadata was passed, but no features present in it
                are also present as tips or internal nodes in the tree.
-            6. The ordination AND feature table don't have exactly the same
-               samples.
+            6. The ordination and feature table don't share any samples.
+            7. The feature table contains more samples than the ordination, AND
+               filter_extra_samples is False.
+            8. The ordination contains more samples than the feature table.
 
     References
     ----------
@@ -186,6 +188,7 @@ def match_inputs(
 
         # don't allow for disjoint datasets
         if not (table_ids & ord_ids):
+            # Error condition 6
             raise DataMatchingError(
                 "No samples in the feature table are present in the "
                 "ordination"
@@ -195,6 +198,7 @@ def match_inputs(
             extra = table_ids - ord_ids
             if extra:
                 if not filter_extra_samples:
+                    # Error condition 7
                     raise DataMatchingError(
                         "The feature table has more samples than the "
                         "ordination. These are the problematic sample "
@@ -206,6 +210,7 @@ def match_inputs(
                 # We'll remove now-empty features from the table later in
                 # the code
         else:
+            # Error condition 8
             raise DataMatchingError(
                 "The ordination has more samples than the feature table."
             )

--- a/tests/python/test_core.py
+++ b/tests/python/test_core.py
@@ -751,6 +751,7 @@ DICT_A = {
         ["1", "0", "4", "jkl"],
     ],
     "feature_metadata_columns": [],
+    "split_taxonomy_columns": [],
     "compressed_tip_metadata": {},
     "compressed_int_metadata": {},
     "emperor_div": "",

--- a/tests/python/test_tools.py
+++ b/tests/python/test_tools.py
@@ -98,9 +98,9 @@ class TestTools(unittest.TestCase):
                 proportion_explained=proportion_explained)
 
     def test_match_inputs_nothing_dropped(self):
-        filtered_table, filtered_sample_md, t_md, i_md, taxcols = tools.match_inputs(
-            self.bp_tree, self.table, self.sample_metadata
-        )
+        (
+            filtered_table, filtered_sample_md, t_md, i_md, taxcols
+        ) = tools.match_inputs(self.bp_tree, self.table, self.sample_metadata)
         self.assertEqual(filtered_table, self.table)
         assert_frame_equal(filtered_sample_md, self.sample_metadata)
         # We didn't pass in any feature metadata, so we shouldn't get any out
@@ -111,7 +111,9 @@ class TestTools(unittest.TestCase):
     def test_match_inputs_nothing_dropped_with_ordination(self):
         # everything is the same since the ordination has a 1:1 match to the
         # feature table
-        filtered_table, filtered_sample_md, t_md, i_md, taxcols = tools.match_inputs(
+        (
+            filtered_table, filtered_sample_md, t_md, i_md, taxcols
+        ) = tools.match_inputs(
             self.bp_tree, self.table, self.sample_metadata,
             ordination=self.ordination
         )
@@ -127,9 +129,9 @@ class TestTools(unittest.TestCase):
         # This is technically allowed (so long as this 1 feature is a tree tip)
         tiny_table = self.table.filter({"a", }, axis='observation',
                                        inplace=False)
-        filtered_tiny_table, filtered_sample_md, tm, im, taxcols = tools.match_inputs(
-            self.bp_tree, tiny_table, self.sample_metadata
-        )
+        (
+            filtered_tiny_table, filtered_sample_md, tm, im, taxcols
+        ) = tools.match_inputs(self.bp_tree, tiny_table, self.sample_metadata)
         self.assertEqual(filtered_tiny_table, tiny_table)
         assert_frame_equal(filtered_sample_md, self.sample_metadata)
         self.assertIsNone(tm)
@@ -297,7 +299,9 @@ class TestTools(unittest.TestCase):
            (self.feature_metadata describes three features, "e", "h", and "a".
             h is an internal node in self.tree, and e and a are tips.)
         """
-        f_table, f_sample_metadata, tip_md, int_md, taxcols = tools.match_inputs(
+        (
+            f_table, f_sample_metadata, tip_md, int_md, taxcols
+        ) = tools.match_inputs(
             self.bp_tree, self.table,
             self.sample_metadata, self.feature_metadata
         )
@@ -494,9 +498,12 @@ class TestTools(unittest.TestCase):
                            ['Sample1', 'Sample2', 'Sample3', 'Sample4',
                             'Sample5'])
 
-        filtered_table, filtered_sample_md, t_md, i_md, taxcols = tools.match_inputs(
+        (
+            filtered_table, filtered_sample_md, t_md, i_md, taxcols
+        ) = tools.match_inputs(
             self.bp_tree, table, self.sample_metadata,
-            ordination=self.ordination, filter_extra_samples=True)
+            ordination=self.ordination, filter_extra_samples=True
+        )
 
         # NOTE: even though 'e' is now empty, it isn't removed now; it'll be
         # removed later on, in remove_empty_samples_and_features().

--- a/tests/python/test_tools.py
+++ b/tests/python/test_tools.py
@@ -14,24 +14,13 @@ from skbio import TreeNode, OrdinationResults
 from empress import tools
 from empress.taxonomy_utils import split_taxonomy
 from bp import parse_newick, from_skbio_treenode
+from .test_taxonomy_utils import assert_taxcols_ok
 
 
 class TestTools(unittest.TestCase):
 
     def mock_tree_from_nwk(self):
         return TreeNode.read(['(((a:1,e:2):1,b:2)g:1,(:1,d:3)h:2):1;'])
-
-    def _check_taxcols_ok(self, taxcols, exp_num_levels=7):
-        """Checks that a given taxcols list (returned by split_taxonomy())
-           looks how we expect it to. This is done frequently in these tests,
-           which is why it is a utility function here.
-
-           exp_num_levels is the number of levels in the taxonomy -- it
-           defaults to 7, which is the case for the moving pictures dataset
-           (kingdom, phylum, class, order, family, genus, species).
-        """
-        expcols = ["Level {}".format(i) for i in range(1, exp_num_levels + 1)]
-        self.assertEqual(taxcols, expcols)
 
     def setUp(self):
         self.tree = self.mock_tree_from_nwk()
@@ -326,7 +315,7 @@ class TestTools(unittest.TestCase):
         self.assertListEqual(list(tip_md.columns), self.exp_split_fm_cols)
         self.assertListEqual(list(int_md.columns), self.exp_split_fm_cols)
         # Check that the split-up taxonomy columns look good
-        self._check_taxcols_ok(taxcols)
+        assert_taxcols_ok(taxcols)
 
     def test_match_inputs_feature_metadata_no_features_in_tree(self):
         """Tests that feature names not corresponding to internal nodes / tips
@@ -371,7 +360,7 @@ class TestTools(unittest.TestCase):
         self.assertListEqual(list(t_fm.columns), self.exp_split_fm_cols)
         self.assertListEqual(list(i_fm.columns), self.exp_split_fm_cols)
         # Check that the split-up taxonomy columns look good
-        self._check_taxcols_ok(taxcols)
+        assert_taxcols_ok(taxcols)
 
     def test_match_inputs_feature_metadata_root_metadata_allowed(self):
         """Tests that feature metadata for the root node is preserved."""
@@ -393,7 +382,7 @@ class TestTools(unittest.TestCase):
         # is important to verify, since it's the root)
         assert_frame_equal(t_fm, split_fm.loc[["a"]])
         assert_frame_equal(i_fm, split_fm.loc[["g", "i"]], check_like=True)
-        self._check_taxcols_ok(taxcols1)
+        assert_taxcols_ok(taxcols1)
         self.assertEqual(taxcols1, taxcols2)
 
     def test_match_inputs_feature_metadata_duplicate_name_internal_node(self):
@@ -423,7 +412,7 @@ class TestTools(unittest.TestCase):
         # kept, even though g and i were both duplicate node names.
         assert_frame_equal(t_fm, split_fm.loc[["a"]])
         assert_frame_equal(i_fm, split_fm.loc[["g", "i"]], check_like=True)
-        self._check_taxcols_ok(taxcols1)
+        assert_taxcols_ok(taxcols1)
         self.assertEqual(taxcols1, taxcols2)
 
     def test_match_inputs_feature_metadata_only_internal_node_metadata(self):
@@ -448,7 +437,7 @@ class TestTools(unittest.TestCase):
         self.assertListEqual(list(i_fm.columns), self.exp_split_fm_cols)
         # 4) Check that the taxonomy columns produced by splitting the
         # taxonomic feature metadata were produced as expected
-        self._check_taxcols_ok(taxcols1)
+        assert_taxcols_ok(taxcols1)
         self.assertEqual(taxcols1, taxcols2)
 
     def test_disjoint_table_and_ordination(self):

--- a/tests/python/test_tools.py
+++ b/tests/python/test_tools.py
@@ -21,6 +21,18 @@ class TestTools(unittest.TestCase):
     def mock_tree_from_nwk(self):
         return TreeNode.read(['(((a:1,e:2):1,b:2)g:1,(:1,d:3)h:2):1;'])
 
+    def _check_taxcols_ok(self, taxcols, exp_num_levels=7):
+        """Checks that a given taxcols list (returned by split_taxonomy())
+           looks how we expect it to. This is done frequently in these tests,
+           which is why it is a utility function here.
+
+           exp_num_levels is the number of levels in the taxonomy -- it
+           defaults to 7, which is the case for the moving pictures dataset
+           (kingdom, phylum, class, order, family, genus, species).
+        """
+        expcols = ["Level {}".format(i) for i in range(1, exp_num_levels + 1)]
+        self.assertEqual(taxcols, expcols)
+
     def setUp(self):
         self.tree = self.mock_tree_from_nwk()
         self.bp_tree = from_skbio_treenode(self.tree)
@@ -64,7 +76,7 @@ class TestTools(unittest.TestCase):
             },
             index=["e", "h", "a"]
         )
-        self.split_tax_fm = split_taxonomy(self.feature_metadata)
+        self.split_tax_fm, self.taxcols = split_taxonomy(self.feature_metadata)
         self.tip_md = self.split_tax_fm.loc[["a", "e"]]
         self.int_md = self.split_tax_fm.loc[["h"]]
         # This is designed to match the shearing that's done in the core test
@@ -97,7 +109,7 @@ class TestTools(unittest.TestCase):
                 proportion_explained=proportion_explained)
 
     def test_match_inputs_nothing_dropped(self):
-        filtered_table, filtered_sample_md, t_md, i_md = tools.match_inputs(
+        filtered_table, filtered_sample_md, t_md, i_md, taxcols = tools.match_inputs(
             self.bp_tree, self.table, self.sample_metadata
         )
         self.assertEqual(filtered_table, self.table)
@@ -105,11 +117,12 @@ class TestTools(unittest.TestCase):
         # We didn't pass in any feature metadata, so we shouldn't get any out
         self.assertIsNone(t_md)
         self.assertIsNone(i_md)
+        self.assertEqual(taxcols, [])
 
     def test_match_inputs_nothing_dropped_with_ordination(self):
         # everything is the same since the ordination has a 1:1 match to the
         # feature table
-        filtered_table, filtered_sample_md, t_md, i_md = tools.match_inputs(
+        filtered_table, filtered_sample_md, t_md, i_md, taxcols = tools.match_inputs(
             self.bp_tree, self.table, self.sample_metadata,
             ordination=self.ordination
         )
@@ -119,18 +132,20 @@ class TestTools(unittest.TestCase):
         # We didn't pass in any feature metadata, so we shouldn't get any out
         self.assertIsNone(t_md)
         self.assertIsNone(i_md)
+        self.assertEqual(taxcols, [])
 
     def test_match_inputs_only_1_feature_in_table(self):
         # This is technically allowed (so long as this 1 feature is a tree tip)
         tiny_table = self.table.filter({"a", }, axis='observation',
                                        inplace=False)
-        filtered_tiny_table, filtered_sample_md, tm, im = tools.match_inputs(
+        filtered_tiny_table, filtered_sample_md, tm, im, taxcols = tools.match_inputs(
             self.bp_tree, tiny_table, self.sample_metadata
         )
         self.assertEqual(filtered_tiny_table, tiny_table)
         assert_frame_equal(filtered_sample_md, self.sample_metadata)
         self.assertIsNone(tm)
         self.assertIsNone(im)
+        self.assertEqual(taxcols, [])
 
     def test_match_inputs_no_tips_in_table(self):
         bad_table = self.table.copy()
@@ -203,7 +218,7 @@ class TestTools(unittest.TestCase):
                 "visualization."
             )
         ):
-            out_table, out_sm, tm, im = tools.match_inputs(
+            out_table, out_sm, tm, im, taxcols = tools.match_inputs(
                 self.bp_tree, bad_table, self.sample_metadata,
                 filter_missing_features=True
             )
@@ -217,6 +232,10 @@ class TestTools(unittest.TestCase):
         assert_frame_equal(
             out_sm, self.sample_metadata
         )
+        # We didn't pass in any feature metadata, so we shouldn't get any out
+        self.assertIsNone(tm)
+        self.assertIsNone(im)
+        self.assertEqual(taxcols, [])
 
     def test_match_inputs_ignore_missing_samples_error(self):
         # Replace one of the sample IDs in the table with some junk
@@ -246,7 +265,7 @@ class TestTools(unittest.TestCase):
                 "metadata."
             )
         ):
-            out_table, out_sm, tm, im = tools.match_inputs(
+            out_table, out_sm, tm, im, taxcols = tools.match_inputs(
                 self.bp_tree, bad_table, self.sample_metadata,
                 ignore_missing_samples=True
             )
@@ -278,13 +297,18 @@ class TestTools(unittest.TestCase):
             check_dtype=False
         )
 
+        # We didn't pass in any feature metadata, so we shouldn't get any back
+        self.assertIsNone(tm)
+        self.assertIsNone(im)
+        self.assertEqual(taxcols, [])
+
     def test_match_inputs_feature_metadata_nothing_dropped(self):
         """Tests that tip/internal node names allowed as entries in feat. md.
 
            (self.feature_metadata describes three features, "e", "h", and "a".
             h is an internal node in self.tree, and e and a are tips.)
         """
-        f_table, f_sample_metadata, tip_md, int_md = tools.match_inputs(
+        f_table, f_sample_metadata, tip_md, int_md, taxcols = tools.match_inputs(
             self.bp_tree, self.table,
             self.sample_metadata, self.feature_metadata
         )
@@ -301,6 +325,8 @@ class TestTools(unittest.TestCase):
         # Check that the tip + internal node metadata have identical columns
         self.assertListEqual(list(tip_md.columns), self.exp_split_fm_cols)
         self.assertListEqual(list(int_md.columns), self.exp_split_fm_cols)
+        # Check that the split-up taxonomy columns look good
+        self._check_taxcols_ok(taxcols)
 
     def test_match_inputs_feature_metadata_no_features_in_tree(self):
         """Tests that feature names not corresponding to internal nodes / tips
@@ -328,7 +354,7 @@ class TestTools(unittest.TestCase):
         # (since it's actually in the tree, while "asdf" and "hjkl" aren't)
         bad_fm = self.feature_metadata.copy()
         bad_fm.index = ["e", "asdf", "hjkl"]
-        f_table, f_sample_metadata, t_fm, i_fm = tools.match_inputs(
+        f_table, f_sample_metadata, t_fm, i_fm, taxcols = tools.match_inputs(
             self.bp_tree, self.table, self.sample_metadata, bad_fm
         )
         self.assertEqual(f_table, self.table)
@@ -344,6 +370,8 @@ class TestTools(unittest.TestCase):
         # the generated HTML... but may as well check.)
         self.assertListEqual(list(t_fm.columns), self.exp_split_fm_cols)
         self.assertListEqual(list(i_fm.columns), self.exp_split_fm_cols)
+        # Check that the split-up taxonomy columns look good
+        self._check_taxcols_ok(taxcols)
 
     def test_match_inputs_feature_metadata_root_metadata_allowed(self):
         """Tests that feature metadata for the root node is preserved."""
@@ -351,7 +379,7 @@ class TestTools(unittest.TestCase):
         t = parse_newick('(((a:1,e:2):1,b:2)g:1,(:1,d:3)h:2)i:1;')
         fm = self.feature_metadata.copy()
         fm.index = ["a", "g", "i"]
-        f_table, f_sample_metadata, t_fm, i_fm = tools.match_inputs(
+        f_table, f_sample_metadata, t_fm, i_fm, taxcols1 = tools.match_inputs(
             t, self.table, self.sample_metadata, fm
         )
         # (check that we didn't mess up the table / sample metadata matching by
@@ -359,40 +387,44 @@ class TestTools(unittest.TestCase):
         self.assertEqual(f_table, self.table)
         assert_frame_equal(f_sample_metadata, self.sample_metadata)
 
-        split_fm = split_taxonomy(fm)
+        split_fm, taxcols2 = split_taxonomy(fm)
         # Main point of this test: all of the feature metadata should have been
         # kept, since a, g, and i are all included in the tree (i in particular
         # is important to verify, since it's the root)
         assert_frame_equal(t_fm, split_fm.loc[["a"]])
         assert_frame_equal(i_fm, split_fm.loc[["g", "i"]], check_like=True)
+        self._check_taxcols_ok(taxcols1)
+        self.assertEqual(taxcols1, taxcols2)
 
     def test_match_inputs_feature_metadata_duplicate_name_internal_node(self):
         """Tests that feature metadata for internal nodes with duplicate names
            is preserved.
 
-           In the JS interface, there are two options for coloring nodes by
-           feature metadata: 1) just coloring tips (and propagating
-           clades with uniform feature metadata upwards), or 2) coloring all
-           nodes with feature metadata, which can include internal nodes. In
-           2), internal nodes with the same name will have the same feature
-           metadata color.
+           In the JS interface, there are two options for coloring nodes by a
+           given feature metadata column: 1) just coloring tips (and
+           propagating clades with the same value in this feature metadata
+           column upwards), or 2) coloring all nodes with feature metadata,
+           which can include internal nodes. In 2), internal nodes with the
+           same name will have the same feature metadata color.
         """
         # Slightly modified version of self.tree with duplicate internal node
         # names (i and g)
         t = parse_newick('(((a:1,e:2)i:1,b:2)g:1,(:1,d:3)g:2)i:1;')
         fm = self.feature_metadata.copy()
         fm.index = ["a", "g", "i"]
-        f_table, f_sample_metadata, t_fm, i_fm = tools.match_inputs(
+        f_table, f_sample_metadata, t_fm, i_fm, taxcols1 = tools.match_inputs(
             t, self.table, self.sample_metadata, fm
         )
         self.assertEqual(f_table, self.table)
         assert_frame_equal(f_sample_metadata, self.sample_metadata)
 
-        split_fm = split_taxonomy(fm)
+        split_fm, taxcols2 = split_taxonomy(fm)
         # Main point of this test: all of the feature metadata should have been
         # kept, even though g and i were both duplicate node names.
         assert_frame_equal(t_fm, split_fm.loc[["a"]])
         assert_frame_equal(i_fm, split_fm.loc[["g", "i"]], check_like=True)
+        self._check_taxcols_ok(taxcols1)
+        self.assertEqual(taxcols1, taxcols2)
 
     def test_match_inputs_feature_metadata_only_internal_node_metadata(self):
         """Tests that feature metadata only for internal nodes is allowed."""
@@ -400,13 +432,13 @@ class TestTools(unittest.TestCase):
         t = parse_newick('(((a:1,e:2):1,b:2)g:1,(:1,d:3)h:2)i:1;')
         fm = self.feature_metadata.copy()
         fm.index = ["h", "g", "i"]
-        f_table, f_sample_metadata, t_fm, i_fm = tools.match_inputs(
+        f_table, f_sample_metadata, t_fm, i_fm, taxcols1 = tools.match_inputs(
             t, self.table, self.sample_metadata, fm
         )
         self.assertEqual(f_table, self.table)
         assert_frame_equal(f_sample_metadata, self.sample_metadata)
 
-        split_fm = split_taxonomy(fm)
+        split_fm, taxcols2 = split_taxonomy(fm)
         # 1) Check that tip metadata is empty
         self.assertEqual(len(t_fm.index), 0)
         # 2) Check that internal node metadata was preserved
@@ -414,6 +446,10 @@ class TestTools(unittest.TestCase):
         # 3) Check that columns on both DFs are identical
         self.assertListEqual(list(t_fm.columns), self.exp_split_fm_cols)
         self.assertListEqual(list(i_fm.columns), self.exp_split_fm_cols)
+        # 4) Check that the taxonomy columns produced by splitting the
+        # taxonomic feature metadata were produced as expected
+        self._check_taxcols_ok(taxcols1)
+        self.assertEqual(taxcols1, taxcols2)
 
     def test_disjoint_table_and_ordination(self):
         self.ordination.samples.index = pd.Index(['Zample1', 'Zample2',
@@ -469,7 +505,7 @@ class TestTools(unittest.TestCase):
                            ['Sample1', 'Sample2', 'Sample3', 'Sample4',
                             'Sample5'])
 
-        filtered_table, filtered_sample_md, t_md, i_md = tools.match_inputs(
+        filtered_table, filtered_sample_md, t_md, i_md, taxcols = tools.match_inputs(
             self.bp_tree, table, self.sample_metadata,
             ordination=self.ordination, filter_extra_samples=True)
 
@@ -485,6 +521,7 @@ class TestTools(unittest.TestCase):
         # We didn't pass in any feature metadata, so we shouldn't get any out
         self.assertIsNone(t_md)
         self.assertIsNone(i_md)
+        self.assertEqual(taxcols, [])
 
     def test_shifting(self):
         # helper test function to count number of bits in the number

--- a/tests/test-animation-panel-handler.js
+++ b/tests/test-animation-panel-handler.js
@@ -93,7 +93,7 @@ require([
                 smCols,
                 sm
             );
-            var empress = new Empress({ size: 0 }, biom, [], {}, {}, null);
+            var empress = new Empress({ size: 0 }, biom, [], [], {}, {}, null);
             var animator = new Animator(
                 empress,
                 new Legend(

--- a/tests/test-barplots.js
+++ b/tests/test-barplots.js
@@ -29,6 +29,7 @@ require([
                     this.testData.tree,
                     this.testData.biom,
                     this.testData.fmCols,
+                    this.testData.splitTaxCols,
                     this.testData.tm,
                     this.testData.im,
                     this.testData.canvas
@@ -112,6 +113,7 @@ require([
             this.testData.tree,
             this.testData.biom,
             [],
+            [],
             {},
             {},
             this.testData.canvas
@@ -123,6 +125,7 @@ require([
             this.testData.tree,
             null,
             [],
+            [],
             {},
             {},
             this.testData.canvas
@@ -132,6 +135,7 @@ require([
             this.testData.tree,
             null,
             this.testData.fmCols,
+            [],
             this.testData.tm,
             this.testData.im,
             this.testData.canvas
@@ -140,6 +144,7 @@ require([
         var empWithSM = new Empress(
             this.testData.tree,
             this.testData.biom,
+            [],
             [],
             {},
             {},
@@ -168,6 +173,7 @@ require([
             this.testData.tree,
             null,
             this.testData.fmCols,
+            [],
             this.testData.tm,
             this.testData.im,
             this.testData.canvas
@@ -183,6 +189,7 @@ require([
         var empWithJustSM = new Empress(
             this.testData.tree,
             this.testData.biom,
+            [],
             [],
             {},
             {},

--- a/tests/test-circular-layout-computation.js
+++ b/tests/test-circular-layout-computation.js
@@ -181,6 +181,7 @@ require(["jquery", "BPTree", "BiomTable", "Empress"], function (
                     tree,
                     biom,
                     [], // feature metadata columns
+                    [], // split taxonomy columns
                     {}, // tip metadata
                     {}, // internal node metadata
                     null // canvas

--- a/tests/test-empress.js
+++ b/tests/test-empress.js
@@ -468,6 +468,7 @@ require([
                 testData.tree,
                 null,
                 testData.fmCols,
+                testData.splitTaxCols,
                 testData.tm,
                 testData.im,
                 testData.canvas
@@ -1019,6 +1020,7 @@ require([
                 testData.tree,
                 tinyBiom,
                 testData.fmCols,
+                testData.splitTaxCols,
                 testData.tm,
                 testData.im,
                 testData.canvas

--- a/tests/test-empress.js
+++ b/tests/test-empress.js
@@ -1081,6 +1081,90 @@ require([
                 );
             }, /F. metadata coloring method "i'm invalid!" unrecognized./);
         });
+        test("Test getUniqueFeatureMetadataInfo with ancestor taxonomy propagation (lowest level, just tip metadata)", function () {
+            var stEmp = UtilitiesForTesting.getEmpressForAncestorTaxProp();
+            var info = stEmp.getUniqueFeatureMetadataInfo("f2", "tip");
+            var uniqVals = ["1; 2", "2; 2"];
+            deepEqual(info.sortedUniqueValues, uniqVals);
+            // Check that the uniqueValueToFeatures object looks good
+            deepEqual(
+                new Set(Object.keys(info.uniqueValueToFeatures)),
+                new Set(uniqVals)
+            );
+            // Two tips have the "1; 2" taxonomy, and two tips have the "2; 2"
+            // taxonomy. ... Of course, in practice, these will probably be
+            // fancy strings like "k__Bacteria" or something, so the taxonomy
+            // displayed will look nicer
+            deepEqual(
+                new Set(info.uniqueValueToFeatures["1; 2"]),
+                new Set([2, 3])
+            );
+            deepEqual(
+                new Set(info.uniqueValueToFeatures["2; 2"]),
+                new Set([1, 6])
+            );
+        });
+        test("Test getUniqueFeatureMetadataInfo with ancestor taxonomy propagation (highest level, just tip metadata)", function () {
+            var stEmp = UtilitiesForTesting.getEmpressForAncestorTaxProp();
+            var info = stEmp.getUniqueFeatureMetadataInfo("f1", "tip");
+            var uniqVals = ["1", "2"];
+            deepEqual(info.sortedUniqueValues, uniqVals);
+            // Check that the uniqueValueToFeatures object looks good
+            deepEqual(
+                new Set(Object.keys(info.uniqueValueToFeatures)),
+                new Set(uniqVals)
+            );
+            deepEqual(
+                new Set(info.uniqueValueToFeatures["1"]),
+                new Set([2, 3])
+            );
+            deepEqual(
+                new Set(info.uniqueValueToFeatures["2"]),
+                new Set([1, 6])
+            );
+        });
+        test("Test getUniqueFeatureMetadataInfo with ancestor taxonomy propagation (lowest level, all f. metadata)", function () {
+            var stEmp = UtilitiesForTesting.getEmpressForAncestorTaxProp();
+            var info = stEmp.getUniqueFeatureMetadataInfo("f2", "all");
+            var uniqVals = ["1; 1", "1; 2", "2; 2"];
+            deepEqual(info.sortedUniqueValues, uniqVals);
+            // Check that the uniqueValueToFeatures object looks good
+            deepEqual(
+                new Set(Object.keys(info.uniqueValueToFeatures)),
+                new Set(uniqVals)
+            );
+            deepEqual(
+                new Set(info.uniqueValueToFeatures["1; 1"]),
+                new Set([4, 5])
+            );
+            deepEqual(
+                new Set(info.uniqueValueToFeatures["1; 2"]),
+                new Set([2, 3])
+            );
+            deepEqual(
+                new Set(info.uniqueValueToFeatures["2; 2"]),
+                new Set([1, 6])
+            );
+        });
+        test("Test getUniqueFeatureMetadataInfo with ancestor taxonomy propagation (highest level, all f. metadata)", function () {
+            var stEmp = UtilitiesForTesting.getEmpressForAncestorTaxProp();
+            var info = stEmp.getUniqueFeatureMetadataInfo("f1", "all");
+            var uniqVals = ["1", "2"];
+            deepEqual(info.sortedUniqueValues, uniqVals);
+            // Check that the uniqueValueToFeatures object looks good
+            deepEqual(
+                new Set(Object.keys(info.uniqueValueToFeatures)),
+                new Set(uniqVals)
+            );
+            deepEqual(
+                new Set(info.uniqueValueToFeatures["1"]),
+                new Set([2, 3, 4, 5])
+            );
+            deepEqual(
+                new Set(info.uniqueValueToFeatures["2"]),
+                new Set([1, 6])
+            );
+        });
         test("Test _getNodeAngleInfo", function () {
             var scope = this;
             this.empress.updateLayout("Circular");

--- a/tests/utilities-for-testing.js
+++ b/tests/utilities-for-testing.js
@@ -115,6 +115,7 @@ define(["Empress", "BPTree", "BiomTable"], function (
             ["b", "4", "t4"],
         ];
         var featureColumns = ["f1", "f2"];
+        var splitTaxColumns = [];
         var tipMetadata = {
             1: ["2", "2"],
             2: ["1", "2"],
@@ -137,6 +138,7 @@ define(["Empress", "BPTree", "BiomTable"], function (
                 tree,
                 biom,
                 featureColumns,
+                splitTaxColumns,
                 tipMetadata,
                 intMetadata,
                 canvas
@@ -156,6 +158,7 @@ define(["Empress", "BPTree", "BiomTable"], function (
             tdToInd: tdToInd,
             biom: biom,
             fmCols: featureColumns,
+            splitTaxCols: splitTaxColumns,
             tm: tipMetadata,
             im: intMetadata,
             canvas: canvas,

--- a/tests/utilities-for-testing.js
+++ b/tests/utilities-for-testing.js
@@ -166,6 +166,34 @@ define(["Empress", "BPTree", "BiomTable"], function (
     }
 
     /**
+     * Returns an Empress object created from the test data returned by
+     * getTestData(), with the key distinction that all feature metadata
+     * columns are "declared" as split taxonomy columns.
+     *
+     * Abstracting this is surprisingly useful for testing this functionality
+     * in many different ways -- it lets us avoid re-typing a lot of stuff.
+     *
+     * @return {Empress} testEmpress
+     */
+    function getEmpressForAncestorTaxProp() {
+        // Need to create a new Empress object, since the default test one has no
+        // split taxonomy columns "declared" on initialization
+        var testData = getTestData();
+        return new Empress(
+            testData.tree,
+            null,
+            testData.fmCols,
+            // Let's say that f1 and f2 are both split taxonomy columns -- our
+            // declaration of them in this order means that f1 is the highest
+            // level and f2 is the lowest level
+            testData.fmCols,
+            testData.tm,
+            testData.im,
+            testData.canvas
+        );
+    }
+
+    /**
      * Returns reference SVGs for the unique values [0, 1, 2, 3, 4] and the
      * color map "Viridis".
      *
@@ -358,6 +386,7 @@ define(["Empress", "BPTree", "BiomTable"], function (
 
     return {
         getTestData: getTestData,
+        getEmpressForAncestorTaxProp: getEmpressForAncestorTaxProp,
         approxDeepEqual: approxDeepEqual,
         approxDeepEqualMulti: approxDeepEqualMulti,
         getReferenceSVGs: getReferenceSVGs,


### PR DESCRIPTION
This is an alternate version of #482 that avoids dramatically increasing the size of the taxonomy information stored in the QZV -- instead, each entry in the feature metadata is "expanded" as needed in the JS. This means that in the worst case (visualizing the lowest level of a taxonomy, e.g. "Level 7" / species) we just need to stitch back together the original taxonomy for every tip described in the feature metadata (this process could be made more efficient -- see comment added in a95b652).

This works by passing a list of the "split taxonomy columns", in descending rank order (i.e. `Level 1`, `Level 2`, ...) from the Python to the JS code, which (in certain contexts) uses this list to determine how much if any ancestor data to get for a given feature metadata column. Doing things in this way may make life easier in the future, since it'll let us name the taxonomy columns (after creating them) whatever we want, so we can do things like use 0-indexing / use a different term than `Level` / etc. if desired without breaking this functionality.

As with #482, this closes #473 and closes #422.

![fancy](https://user-images.githubusercontent.com/4177727/108157893-a75a8780-7098-11eb-9adb-87363cad2de1.png)