### PR TITLE
Fix bug with running standalone version; account for NumPy dependency in standalone install instructions; a few small changes w/r/t node circle options

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,14 @@ Empress is available as either a standalone program or a QIIME 2 plugin. The sta
 
 ## Standalone Version
 
-EMPress is available through [PyPI](https://PyPI.org/project/empress/). Run the following command to install Empress:
+Empress is available through [PyPI](https://PyPI.org/project/empress/). We recommend installing Empress into an environment (e.g. a [conda](https://docs.conda.io/) environment) using a Python version of at least 3.6.
 
-`pip install empress`
+Run the following commands to install Empress:
+
+```bash
+pip install cython "numpy >= 1.12.0"
+pip install empress
+```
 
 Try running the command `empress --help` to ensure that Empress has been installed properly. If you see details for the different Empress commands then the installation has succeeded and you are ready to start using Empress!
 

--- a/empress/_plot_utils.py
+++ b/empress/_plot_utils.py
@@ -10,7 +10,6 @@
 import os
 import pkg_resources
 
-import q2templates
 from bp import parse_newick
 import numpy as np
 import pandas as pd
@@ -55,6 +54,7 @@ def save_viz(viz, output_dir, q2=True):
     viz.copy_support_files(output_dir)
 
     if q2:
+        import q2templates
         index = os.path.join(TEMPLATES, 'index.html')
         q2templates.render(index, output_dir)
 

--- a/empress/support_files/templates/side-panel.html
+++ b/empress/support_files/templates/side-panel.html
@@ -412,8 +412,8 @@
         <option value=0>Show internal node circles</option>
         <option value=1>Show all node circles</option>
         <option value=2>Hide all node circles</option>
-        <option value=3 selected>Show node circles of internal nodes with only one 
-                        descendant
+        <option value=3 selected>Show node circles for internal nodes with only one
+                        child
         </option>
       </select>
     </label>

--- a/empress/support_files/templates/side-panel.html
+++ b/empress/support_files/templates/side-panel.html
@@ -409,11 +409,12 @@
     <label for="display-nodes-select">Show node circles?</label>
     <label class="select-container">
       <select id="display-nodes-select">
+        <option value=2>Hide all node circles</option>
+        <option value=3 selected>
+            Show node circles for internal nodes with only one child
+        </option>
         <option value=0>Show internal node circles</option>
         <option value=1>Show all node circles</option>
-        <option value=2>Hide all node circles</option>
-        <option value=3 selected>Show node circles for internal nodes with only one
-                        child
         </option>
       </select>
     </label>

--- a/empress/support_files/templates/side-panel.html
+++ b/empress/support_files/templates/side-panel.html
@@ -419,7 +419,7 @@
     </label>
   </p>
   <p class="side-panel-notes indented">
-    If checked, this draws circles at all nodes' positions.
+    Controls behavior of when to draw circles at nodes' positions.
   </p>
   <hr />
   <p class="side-panel-inner-header">

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,10 @@ setup(
                     'support_files/templates/*.html',
                     'citations.bib']},
     data_files={},
+    # Yanked from Qurro: NumPy and Cython need to be installed before
+    # trying to install EMPress / other pip packages.
+    # https://github.com/biocore/qurro/blob/master/setup.py
+    setup_requires=["cython", "numpy >= 1.12.0"],
     install_requires=base,
     extras_require={'test': test, 'all': all_deps},
     long_description=long_description,


### PR DESCRIPTION
There's a line in `_plot_utils.py` that imports `q2templates`, a package which is (usually) only available in QIIME 2 conda environments. This was breaking the standalone script when ran outside of a QIIME 2 environment.

To fix this, we can just move the import down so that it's only done if EMPress is being run through QIIME 2. This fixes the problem.

A very warm thank you to @ammaraziz for pointing this out!

Edit - I also made a few changes in this PR's later commits that make the UI for changing the node circle behavior a bit nicer. Should be limited to just cosmetic changes to the HTML.