### PR TITLE
BLD: Small tweaks to GH Actions workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,7 @@
+# Tests EMPress' Python and JS code within a QIIME 2 conda environment.
+# Also lints and stylechecks the code (both Python and JS).
+# When tests pass, this runs "make docs" to generate various test QIIME 2
+# visualizations (.qzv files) and uploads them to McHelper.
 name: Main CI
 
 # Controls when the action will run. 
@@ -42,7 +46,7 @@ jobs:
       - name: Install flake8
         run: conda run -n base pip install flake8
 
-      - name: Run linters
+      - name: Run linting and stylechecking
         run: |
           conda run -n base make stylecheck
 
@@ -53,7 +57,7 @@ jobs:
           python-version: 3.6
           conda-channels: anaconda, conda-forge
 
-      - name: Create QIIME 2 enviroment
+      - name: Create QIIME 2 conda enviroment
         run: |
           wget https://data.qiime2.org/distro/core/qiime2-2020.6-py36-linux-conda.yml
           conda env create -n qiime2-dev --file qiime2-2020.6-py36-linux-conda.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Set up Node.js enviroment
+      - name: Set up Node.js
         uses: actions/setup-node@v1
         with:
           # Can use a matrix of Node.js versions in the future if desired;
@@ -57,7 +57,7 @@ jobs:
           python-version: 3.6
           conda-channels: anaconda, conda-forge
 
-      - name: Create QIIME 2 conda enviroment
+      - name: Create QIIME 2 conda environment
         run: |
           wget https://data.qiime2.org/distro/core/qiime2-2020.6-py36-linux-conda.yml
           conda env create -n qiime2-dev --file qiime2-2020.6-py36-linux-conda.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Empress CI
+name: Main CI
 
 # Controls when the action will run. 
 on:
@@ -14,10 +14,6 @@ jobs:
   build:
     # The type of runner that the job will run on (available options are window/macOS/linux)
     runs-on: ubuntu-latest
-    # we can add more versions of node.js in the future
-    strategy:
-      matrix:
-        node-version: [14.x]
     
     # used in McHelper (similar to TRAVIS_PULL_REQUEST variable)
     env:
@@ -30,10 +26,14 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-  
+
       - name: Set up Node.js enviroment
         uses: actions/setup-node@v1
         with:
+          # Can use a matrix of Node.js versions in the future if desired;
+          # however, since Node.js should only be used when developing
+          # EMPress, it's not an urgent priority (and should likely be done
+          # separately from the Python CI stuff to save time)
           node-version: 14
 
       - name: Install Node.js modules
@@ -53,12 +53,12 @@ jobs:
           python-version: 3.6
           conda-channels: anaconda, conda-forge
 
-      - name: Create Qiime enviroment
+      - name: Create QIIME 2 enviroment
         run: |
           wget https://data.qiime2.org/distro/core/qiime2-2020.6-py36-linux-conda.yml
-          conda env create -n qiime2-dev --file qiime2-2020.6-py36-linux-conda.yml      
+          conda env create -n qiime2-dev --file qiime2-2020.6-py36-linux-conda.yml
 
-      - name: Install Empress
+      - name: Install EMPress
         run: |
           conda run -n qiime2-dev pip uninstall emperor --yes
           conda run -n qiime2-dev pip install -e .[all] --verbose

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -1,3 +1,6 @@
+# Tests EMPress' Python code, when installed outside of a QIIME 2 conda
+# environment. See https://github.com/biocore/empress/issues/496 for a
+# description of why this is useful.
 name: Standalone CI
 
 # Controls when the action will run. 
@@ -41,7 +44,7 @@ jobs:
         shell: bash -l {0}
         run: conda install flake8 nose
 
-      - name: Install cython & numpy
+      - name: Install Cython & NumPy
         shell: bash -l {0}
         run: pip install cython "numpy >= 1.12.0"
 
@@ -49,7 +52,7 @@ jobs:
         shell: bash -l {0}
         run: pip install -e .[all]
 
-      # tests that don't import qiime2 dependencies
+      # tests that don't import QIIME 2 dependencies
       - name: Run (non-QIIME 2) Python tests
         shell: bash -l {0}
         run: >

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -1,4 +1,4 @@
-name: Empress Standalone CI
+name: Standalone CI
 
 # Controls when the action will run. 
 on:
@@ -14,7 +14,6 @@ jobs:
   build:
     # The type of runner that the job will run on (available options are window/macOS/linux)
     runs-on: ubuntu-latest
-    # we can add more versions of node.js in the future
     strategy:
       matrix:
         # based roughly on https://github.com/conda-incubator/setup-miniconda#example-1-basic-usage

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Empress
-[![EMPress CI](https://github.com/biocore/empress/actions/workflows/main.yml/badge.svg)](https://github.com/biocore/empress/actions/workflows/main.yml)
-[![EMPress Standalone CI](https://github.com/biocore/empress/actions/workflows/standalone.yml/badge.svg)](https://github.com/biocore/empress/actions/workflows/standalone.yml)
+[![Main CI](https://github.com/biocore/empress/actions/workflows/main.yml/badge.svg)](https://github.com/biocore/empress/actions/workflows/main.yml)
+[![Standalone CI](https://github.com/biocore/empress/actions/workflows/standalone.yml/badge.svg)](https://github.com/biocore/empress/actions/workflows/standalone.yml)
 [![PyPI](https://img.shields.io/pypi/v/empress.svg)](https://pypi.org/project/empress)
 
 <!---Empress Logo--->


### PR DESCRIPTION
Nothing big, just some small fixes that should make development easier.

- Remove Node.js matrix for main CI, since the version number is hard-coded currently; this should remove the need to click through multiple pages when accessing the main CI (edit: actually maybe you still need to click through things twice, hm. at least it should simplify the code.)
  - In the future we could add back this matrix and use it to try multiple Node.js versions -- however I don't think it's an urgent priority, since Node.js is only used on the development side (so being exhaustive about versions working probably isn't too important, at least compared to Python versions in the standalone CI)
  - Another concern here is that trying multiple Node.js versions should probably be a separate process from installing/testing the Python code; I think the most efficient way to set this up this would be something like adding a different workflow for JS testing, then adding _another_ workflow for uploading to McHelper that is dependent on both the "JS testing" and "Python testing" workflows passing [but IDK how to do that right now]

- Make some documentation consistent btwn YAML files (e.g. Empress -> EMPress)

- Remove the "Empress" from the workflow names, renaming them to just "Main CI" and "Standalone CI" -- I think this makes the README badges/etc. easier to interpret