### PR TITLE
Automatically resize main legend when changing tree coloring

### DIFF
--- a/empress/support_files/css/empress.css
+++ b/empress/support_files/css/empress.css
@@ -594,6 +594,12 @@ p.side-header button:hover,
 
 /* The legend is resizable, thanks to resize: both; and overflow: auto.
  * See https://stackoverflow.com/a/61976603/10730311.
+ *
+ * The 0.1px bottom padding prevents an unnecessary vertical scrollbar
+ * that kept showing up when setting the legend's width/height back to
+ * their defaults ("") in empress.js. It seems like having a tiny bit
+ * of extra vertical space is needed to get rid of this. It's barely
+ * visible to the user so it shouldn't be a problem.
  */
 #legend-main {
     margin: 20px;
@@ -601,6 +607,7 @@ p.side-header button:hover,
     max-width: 33vw;
     min-height: 30px;
     max-height: 85vh;
+    padding-bottom: 0.1px;
     resize: both;
     overflow: auto;
     background-color: rgba(255, 255, 255, 0.5);

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -2621,6 +2621,20 @@ define([
     };
 
     /**
+     * Set the #legend-main width and height back to their defaults.
+     *
+     * This allows the legend to be resized back to whatever the default
+     * size will be, since manually resizing the legend sets a fixed
+     * width/height value.
+     */
+    Empress.prototype.resizeLegend = function () {
+        // Setting CSS properties to "" causes the default values to be used:
+        // see https://stackoverflow.com/a/21457941.
+        document.getElementById("legend-main").style.width = "";
+        document.getElementById("legend-main").style.height = "";
+    };
+
+    /**
      * Updates the legend based on a categorical color key.
      *
      * This is set up as a public method so that the Animator can update the
@@ -2633,12 +2647,7 @@ define([
      *                         color, expressed in hex format.
      */
     Empress.prototype.updateLegendCategorical = function (name, keyInfo) {
-        // Allow the legend to be resized back to whatever the default
-        // size will be, since manually resizing the legend sets a fixed
-        // width/height value. Setting the width/height to "" will cause the
-        // defaults to be used: https://stackoverflow.com/a/21457941
-        document.getElementById("legend-main").style.width = "";
-        document.getElementById("legend-main").style.height = "";
+        this.resizeLegend();
         this._legend.addCategoricalKey(name, keyInfo);
     };
 

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -2633,6 +2633,12 @@ define([
      *                         color, expressed in hex format.
      */
     Empress.prototype.updateLegendCategorical = function (name, keyInfo) {
+        // Allow the legend to be resized back to whatever the default
+        // size will be, since manually resizing the legend sets a fixed
+        // width/height value. Setting the width/height to "" will cause the
+        // defaults to be used: https://stackoverflow.com/a/21457941
+        document.getElementById("legend-main").style.width = "";
+        document.getElementById("legend-main").style.height = "";
         this._legend.addCategoricalKey(name, keyInfo);
     };
 


### PR DESCRIPTION
The main legend in the application is resizable, and its size will automatically change as the tree is colored by different categories. However, this behavior currently stops working after the user manually resizes the legend at all:

![leg](https://user-images.githubusercontent.com/4177727/116769612-39b0cd00-a9f2-11eb-9cd3-21868265dfa6.gif)

We should keep the ability for users to manually resize the legend, IMO, since the legend can get really large and we don't want it to obstruct the user's view.

It looks like the reason for this is that, when the user manually resizes the legend, that the `width` / `height` attributes of the legend go from being unspecified to being fixed: (note the `element.style` text in the dev console on the right)

![wh](https://user-images.githubusercontent.com/4177727/116769668-94e2bf80-a9f2-11eb-86eb-493d3661acb1.gif)

This PR fixes this, by resetting the width/height of the main legend to their defaults right before we adjust tree coloring:

![Peek 2021-04-30 20-53](https://user-images.githubusercontent.com/4177727/116770129-34558180-a9f6-11eb-82ee-efc9d7da92f3.gif)

It's worth noting that this PR will need to be updated once #484 is merged in so that `Empress.resizeLegend()` is called before creating a continuous legend.