### PR TITLE
throttled onwheel event

### DIFF
--- a/empress/support_files/js/canvas-events.js
+++ b/empress/support_files/js/canvas-events.js
@@ -220,7 +220,7 @@ define(["underscore", "glMatrix", "SelectedNodeMenu"], function (
 
         canvas.onmousedown = mouseDown;
         canvas.onclick = mouseClick;
-        canvas.onwheel = _.throttle(zoomTree, 50);
+        canvas.onwheel = _.throttle(zoomTree, 10);
         canvas.ondblclick = doubleClick;
     };
 

--- a/empress/support_files/js/canvas-events.js
+++ b/empress/support_files/js/canvas-events.js
@@ -220,7 +220,7 @@ define(["underscore", "glMatrix", "SelectedNodeMenu"], function (
 
         canvas.onmousedown = mouseDown;
         canvas.onclick = mouseClick;
-        canvas.onwheel = zoomTree;
+        canvas.onwheel = _.throttle(zoomTree, 50);
         canvas.ondblclick = doubleClick;
     };
 


### PR DESCRIPTION
I don't know if this an issue was created for this but I just tried using empress on a mac laptop and the zoom functionality was incredibly sensitive, which caused the tree to zoom in/out incredibly fast. This PR fixes that issue by throttling the .onwheel event to fire at most 1 every 50 milliseconds.