### PR TITLE
Improves error handling when "shear" but no metadata passed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ jstest:
 stylecheck:
 	jshint $(JSLOCS)
 	prettier --check --tab-width 4 $(JSLOCS) $(CSSLOCS)
-	flake8 empress/*.py tests/python/*.py setup.py
+	flake8 empress/*.py tests/python/*.py setup.py empress/scripts/*.py
 
 # Auto-formats the JS code
 jsstyle:

--- a/empress/core.py
+++ b/empress/core.py
@@ -136,6 +136,11 @@ class Empress():
             # self._validate_and_match_data()
             self.features = feature_metadata.copy()
         else:
+            if shear_to_feature_metadata:
+                raise ValueError(
+                    "Feature metadata must be provided in order to shear "
+                    "to feature metadata."
+                )
             self.features = None
 
         self.ordination = ordination
@@ -224,12 +229,7 @@ class Empress():
 
         else:
             if shear_to_feature_metadata:
-                try:
-                    features = set(self.features.index)
-                except AttributeError:
-                    raise ValueError(
-                        "Feature metadata must be provided in order to shear "
-                        "to feature metadata.")
+                features = set(self.features.index)
                 all_tips = set(bp_tree_tips(self.tree))
                 # check that feature metadata contains at least 1 tip
                 if not features.intersection(all_tips):

--- a/empress/core.py
+++ b/empress/core.py
@@ -224,7 +224,12 @@ class Empress():
 
         else:
             if shear_to_feature_metadata:
-                features = set(self.features.index)
+                try:
+                    features = set(self.features.index)
+                except AttributeError:
+                    raise ValueError(
+                        "Feature metadata must be provided in order to shear "
+                        "to feature metadata.")
                 all_tips = set(bp_tree_tips(self.tree))
                 # check that feature metadata contains at least 1 tip
                 if not features.intersection(all_tips):

--- a/empress/scripts/_cli.py
+++ b/empress/scripts/_cli.py
@@ -15,9 +15,11 @@ def empress():
     """Generates an interactive visualization of a phylogenetic tree."""
     pass
 
+
 # Allow using -h to show help information
 # https://click.palletsprojects.com/en/7.x/documentation/#help-parameter-customization
 CTXSETS = {"help_option_names": ["-h", "--help"]}
+
 
 @empress.command(
     "tree-plot", short_help=desc.TREE_PLOT_DESC, context_settings=CTXSETS

--- a/tests/python/test_core.py
+++ b/tests/python/test_core.py
@@ -204,6 +204,11 @@ class TestCore(unittest.TestCase):
         ):
             Empress(self.tree, feature_metadata=bad_fm)
 
+    def test_init_tree_plot_shear_without_metadata(self):
+        with self.assertRaisesRegex(ValueError,
+                                    "Feature metadata must be provided"):
+            viz = Empress(self.tree, shear_to_feature_metadata=True)
+
     def test_init_only_one_of_table_and_sm_passed(self):
         exp_errmsg = (
             "Both the table and sample metadata should be specified or None. "

--- a/tests/python/test_core.py
+++ b/tests/python/test_core.py
@@ -207,7 +207,7 @@ class TestCore(unittest.TestCase):
     def test_init_tree_plot_shear_without_metadata(self):
         with self.assertRaisesRegex(ValueError,
                                     "Feature metadata must be provided"):
-            viz = Empress(self.tree, shear_to_feature_metadata=True)
+            Empress(self.tree, shear_to_feature_metadata=True)
 
     def test_init_only_one_of_table_and_sm_passed(self):
         exp_errmsg = (


### PR DESCRIPTION
When `tree_plot` is run with `shear-to-feature-metadata`, but no metadata is passed, the following error is produced.
![image](https://user-images.githubusercontent.com/39198770/121439551-03446700-c93b-11eb-9928-376860fcc7d0.png)

This PR explicitly handles that case, improving the error message:
![image](https://user-images.githubusercontent.com/39198770/121439713-56b6b500-c93b-11eb-96c7-1b237b48de11.png)
