### PR TITLE
BUG: Draw node circles as needed in SVG export

### DIFF
--- a/empress/support_files/js/export-util.js
+++ b/empress/support_files/js/export-util.js
@@ -333,11 +333,17 @@ define(["underscore", "chroma", "Colorer"], function (_, chroma, Colorer) {
             bb = bpResults.boundingBox;
         }
 
-        // create a circle for each node
-        if (drawer.showTreeNodes) {
+        // Create a circle for each node, as needed.
+        // Empress.getNodeCoords() will return node coordinate info
+        // dependent upon the settings for showing node circles, so
+        // we don't need to worry about the specifics of which exact node
+        // circles to include here.
+        // If coords.length is 0, then no node circles will be drawn and
+        // we can skip this step.
+        coords = empress.getNodeCoords();
+        if (coords.length > 0) {
             var radius = drawer.NODE_CIRCLE_DIAMETER / 2;
             svg += "<!-- tree nodes -->\n";
-            coords = empress.getNodeCoords();
             for (
                 i = 0;
                 i + drawer.VERTEX_SIZE <= coords.length;


### PR DESCRIPTION
Noticed that node circles were being left out of the SVG tree export, even when node circles are explicitly enabled for some or all nodes.

I believe this was happening because `export-util.js` hadn't been updated in light of #486's changes:

https://github.com/biocore/empress/blob/df3a4da5a5b23d465937112dfa2050f8957bb0ed/empress/support_files/js/export-util.js#L337

The `Drawer.showTreeNodes` flag was removed in #486, so I guess thanks to Javascript's magic `if (drawer.showTreeNodes)` will always silently evaluate to `undefined` (aka false) ._.

This PR fixes this problem. Fortunately, the way #486 is set up seemed to make it pretty easy to get this working again.