### PR TITLE
Allow explicitly passing data to make-dev-page.py without including feature metadata

### DIFF
--- a/tests/python/make-dev-page.py
+++ b/tests/python/make-dev-page.py
@@ -68,7 +68,9 @@ def main(tree, table, sample_metadata, feature_metadata, ordination,
 
     table = table.view(biom.Table)
     sample_metadata = sample_metadata.to_dataframe()
-    feature_metadata = feature_metadata.to_dataframe()
+
+    if feature_metadata is not None:
+        feature_metadata = feature_metadata.to_dataframe()
 
     if ordination is not None:
         ordination = ordination.view(OrdinationResults)


### PR DESCRIPTION
Noticed while going through #530, although this isn't really in scope of that!

The make-dev-page script uses the condition of "if one of `{tree, table, sample metadata}` is None" to determine when to load the default moving pictures data. Since feature metadata isn't checked, this means that the bottom line in the code below will fail with `AttributeError: 'NoneType' object has no attribute 'to_dataframe'` when only passing the tree, table, and sample metadata to the script:

https://github.com/biocore/empress/blob/3d60a2941bea3837dc76750f305b20e212a9c828/tests/python/make-dev-page.py#L46-L71

This PR fixes this, allowing the generation of dev pages without feature metadata.

One thing worth noting is that I don't know if it's possible currently (using make-dev-page.py) to pass an ordination without passing in feature metadata, or to pass in feature metadata without passing in a table / sample metadata -- since these arguments seem to be based on position. (It's totally possible to do this sort of stuff when actually running Empress normally, as shown in e.g. #485, but IDK if replicating this situation is possible in make-dev-page.py. It's not a big deal since this script is only used for testing, though.)