### PR TITLE
Fix BP tree corruption due to numpy uints

### DIFF
--- a/empress/tools.py
+++ b/empress/tools.py
@@ -374,6 +374,9 @@ def shifting(bitlist, size=51):
     if not all(x in [0, 1] for x in bitlist):
         raise ValueError('Your list has values other than 0-1s')
 
+    # Convert all the bits to ints -- if they are np.uint8, etc. instead and
+    # we don't convert them, then this can cause problems: see
+    # https://github.com/biocore/empress/issues/562
     bitlist = [int(x) for x in bitlist]
 
     values = [iter(bitlist)] * size

--- a/empress/tools.py
+++ b/empress/tools.py
@@ -345,19 +345,23 @@ def shifting(bitlist, size=51):
     Parameters
     ----------
     bitlist: list of int
-        The input list of 0-1
+        The input list of bits (0 or 1). Depending on the version of iow
+        installed, the entries in this list might be of a slightly different
+        type (e.g. np.uint8).
     size: int
         The size of the buffer
 
     Returns
     -------
     list of int
-        Representation of the 0-1s as a list of int
+        Representation of the bits as a list of int. Regardless of the types in
+        the input bitlist, the entries in the output list will always have type
+        int.
 
     Raises
     ------
     ValueError
-        If any of the list values is different than 0 or 1
+        If any of the entries in bitlist is not equal to 0 or 1.
 
     References
     ----------
@@ -369,6 +373,8 @@ def shifting(bitlist, size=51):
     """
     if not all(x in [0, 1] for x in bitlist):
         raise ValueError('Your list has values other than 0-1s')
+
+    bitlist = [int(x) for x in bitlist]
 
     values = [iter(bitlist)] * size
     ints = []

--- a/tests/python/test_taxonomy_utils.py
+++ b/tests/python/test_taxonomy_utils.py
@@ -57,9 +57,9 @@ class TestTaxonomyUtils(unittest.TestCase):
         )
 
     def _check_basic_case_worked(self, split_fm, taxcols):
-        """Checks that a given DataFrame (and list of split-up taxonomy columns)
-           matches the expected output from running split_taxonomy() on
-           self.feature_metadata.
+        """Checks that a given DataFrame (and list of split-up taxonomy
+           columns) matches the expected output from running split_taxonomy()
+           on self.feature_metadata.
         """
 
         # Let's verify that split_fm looks how we expect it to look.

--- a/tests/python/test_tools.py
+++ b/tests/python/test_tools.py
@@ -583,6 +583,22 @@ class TestTools(unittest.TestCase):
                                     "than 0-1s"):
             tools.shifting([10])
 
+    def test_shifting_np_uint8(self):
+        # Verifies that https://github.com/biocore/empress/issues/562 is fixed.
+        # Checks that, whether the inputs are ints or np.uint8s, the output is
+        # the same.
+        bits = [1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1]
+        np_bits = [np.uint8(b) for b in bits]
+        expected = [4035]
+
+        o1 = tools.shifting(bits)
+        assert o1 == expected
+        assert type(o1[0]) is int
+
+        o2 = tools.shifting(np_bits)
+        assert o2 == expected
+        assert type(o2[0]) is int
+
     def test_filter_feature_metadata_to_tree_1_tip_filtered(self):
         ft, fi = tools.filter_feature_metadata_to_tree(
             self.tip_md, self.int_md, self.shorn_tree


### PR DESCRIPTION
Closes #562 (which was the cause of the problem discussed in #561).

Strangely enough, I can't seem to get Empress' Python code running within a conda environment that has numpy 2 installed -- I get a weird error from `bp/_bp.pyx` saying that `ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject`. But presumably it _is_ possible to get numpy 2 and empress working together, because that was the set of circumstances that led to #561.

Anyway, all this to say that this PR _should_ fix #562 and make Empress compatible with numpy 2. I can't guarantee that, since I haven't been able to get iow + numpy 2 to play nicely together on my system ... but I imagine we'll eventually need to support numpy 2 anyway, so we may as well address this now.

**Edit:** the build is broken for other reasons (the main build is broken due to -- it looks like -- Q2 2020.6 not being installable any more, due to seaborn version jank?; and the standalone python 3.7 build is broken due to an old version of skbio). I guess fixing the build will be another PR ...