### PR TITLE
Fix build and tests; update Python versions / dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-node@v4
 
       - name: Install Node.js modules
-        run: npm install -g qunit-puppeteer jshint prettier@2.0.5
+        run: npm install -g node-qunit-puppeteer jshint prettier@2.0.5
 
       - name: Install flake8
         run: conda run -n base pip install flake8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,17 +50,17 @@ jobs:
         run: |
           conda run -n base make stylecheck
 
-      - name: Set up conda
-        uses: s-weigand/setup-conda@v1
-        with:
-          update-conda: true
-          python-version: 3.6
-          conda-channels: anaconda, conda-forge
-
-      - name: Create QIIME 2 conda environment
+      - name: Download QIIME 2 conda environment YAML
         run: |
           wget -O q2-env.yml https://raw.githubusercontent.com/qiime2/distributions/dev/2024.10/amplicon/released/qiime2-amplicon-ubuntu-latest-conda.yml
-          conda env create -n qiime2-dev --file q2-env.yml
+
+      # https://github.com/conda-incubator/setup-miniconda#example-3-other-options
+      # (from Qurro's qiime2.yml workflow)
+      - name: Install this QIIME 2 version
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: qiime2-dev
+          environment-file: q2-env.yml
 
       - name: Install EMPress
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,9 @@ jobs:
         run: |
           conda run -n qiime2-dev pip uninstall emperor --yes
           conda run -n qiime2-dev pip install -e .[all] --verbose
+          # to prevent the "linear-tree" tests from failing, require an iow vsn
+          # of at least 1.0.8. see https://github.com/biocore/empress/pull/555.
+          conda run -n qiime2-dev pip install "iow >= 1.0.8"
           conda run -n qiime2-dev qiime dev refresh-cache
 
       - name: Run tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,13 +32,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v1
-        with:
-          # Can use a matrix of Node.js versions in the future if desired;
-          # however, since Node.js should only be used when developing
-          # EMPress, it's not an urgent priority (and should likely be done
-          # separately from the Python CI stuff to save time)
-          node-version: 14
+        uses: actions/setup-node@v4
 
       - name: Install Node.js modules
         run: npm install -g qunit-puppeteer jshint prettier@2.0.5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,12 @@ jobs:
       - name: Install Node.js modules
         run: npm install -g node-qunit-puppeteer jshint prettier@2.0.5
 
+      - name: Set up chrome-sandbox permissions for Puppeteer
+        run: |
+          # from https://github.com/Chia-Network/chia-blockchain/issues/4721#issuecomment-841754056
+          sudo chown root:root $CHROME_DEVEL_SANDBOX
+          sudo chmod 4755 $CHROME_DEVEL_SANDBOX
+
       - name: Install flake8
         run: conda run -n base pip install flake8
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,8 +59,8 @@ jobs:
 
       - name: Create QIIME 2 conda environment
         run: |
-          wget https://data.qiime2.org/distro/core/qiime2-2020.6-py36-linux-conda.yml
-          conda env create -n qiime2-dev --file qiime2-2020.6-py36-linux-conda.yml
+          wget -O q2-env.yml https://raw.githubusercontent.com/qiime2/distributions/dev/2024.10/amplicon/released/qiime2-amplicon-ubuntu-latest-conda.yml
+          conda env create -n qiime2-dev --file q2-env.yml
 
       - name: Install EMPress
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,16 @@ jobs:
     # The type of runner that the job will run on (available options are window/macOS/linux)
     runs-on: ubuntu-latest
     
-    # used in McHelper (similar to TRAVIS_PULL_REQUEST variable)
     env:
+      # used in McHelper (similar to TRAVIS_PULL_REQUEST variable)
       BRANCH_NUMBER: ${{ github.event.number }}
+      # currently, puppeteer gives us the following error:
+      # Error: Failed to launch the browser process!
+      # [4551:4551:0501/052725.614275:FATAL:zygote_host_impl_linux.cc(132)] No usable sandbox! If you are running on Ubuntu 23.10+ or another Linux distro that has disabled unprivileged user namespaces with AppArmor, see https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md. Otherwise see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the (older) SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
+      #
+      # Per the chromium.googlesource.com link above, it looks like setting
+      # this env variable can fix the issue?
+      CHROME_DEVEL_SANDBOX: /opt/google/chrome/chrome-sandbox
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         # based roughly on https://github.com/conda-incubator/setup-miniconda#example-1-basic-usage
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     # used in McHelper (similar to TRAVIS_PULL_REQUEST variable)
     env:

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -26,6 +26,18 @@ jobs:
     env:
       BRANCH_NUMBER: ${{ github.event.number }}
 
+    # https://github.com/conda-incubator/setup-miniconda#use-a-default-shell
+    # Use the same shell for all commands here, preserving the "context" of the
+    # conda environment we set up. (This is a lot nicer-looking than prefixing
+    # all of these commands with "conda run -n empress" or something.)
+    #
+    # See https://stackoverflow.com/q/69070754 and 'bash -c "help set"' for details
+    # about what the "-el {0}" means here.
+    # ^^ copied from metaLJA CI
+    defaults:
+      run:
+        shell: bash -el {0}
+
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # first grab branch from github
@@ -35,28 +47,21 @@ jobs:
           fetch-depth: 0
 
       # https://github.com/conda-incubator/setup-miniconda#example-1-basic-usage
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: empress
           python-version: ${{ matrix.python-version }}
 
-      - name: Install conda packages
-        shell: bash -l {0}
-        run: conda install flake8 nose
-
       - name: Install Cython & NumPy
-        shell: bash -l {0}
         run: pip install cython "numpy >= 1.12.0"
 
       - name: Install EMPress
-        shell: bash -l {0}
         run: pip install -e .[all]
 
       # tests that don't import QIIME 2 dependencies
       - name: Run (non-QIIME 2) Python tests
-        shell: bash -l {0}
         run: >
-          nosetests
+          pytest
           ./tests/python/test_cli.py
           ./tests/python/test_compression_utils.py
           ./tests/python/test_core.py

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -54,7 +54,7 @@ jobs:
 
       # Pinning numpy < 2 per https://github.com/biocore/improved-octo-waddle/issues/59
       - name: Install Cython & NumPy
-        run: pip install cython "numpy >= 1.12.0,<2"
+        run: pip install cython "numpy >= 1.12.0"
 
       - name: Install EMPress
         run: pip install -e .[all]

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         # based roughly on https://github.com/conda-incubator/setup-miniconda#example-1-basic-usage
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     # used in McHelper (similar to TRAVIS_PULL_REQUEST variable)
     env:

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         # based roughly on https://github.com/conda-incubator/setup-miniconda#example-1-basic-usage
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     # used in McHelper (similar to TRAVIS_PULL_REQUEST variable)
     env:

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -52,8 +52,9 @@ jobs:
           activate-environment: empress
           python-version: ${{ matrix.python-version }}
 
+      # Pinning numpy < 2 per https://github.com/biocore/improved-octo-waddle/issues/59
       - name: Install Cython & NumPy
-        run: pip install cython "numpy >= 1.12.0"
+        run: pip install cython "numpy >= 1.12.0,<2"
 
       - name: Install EMPress
         run: pip install -e .[all]

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -54,7 +54,7 @@ jobs:
 
       # Pinning numpy < 2 per https://github.com/biocore/improved-octo-waddle/issues/59
       - name: Install Cython & NumPy
-        run: pip install cython "numpy >= 1.12.0"
+        run: pip install cython "numpy >= 1.12.0,<2"
 
       - name: Install EMPress
         run: pip install -e .[all]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,13 +12,19 @@ You will also need to install a few Node.js packages in order to test Empress'
 JavaScript code.
 
 ```bash
-npm install -g qunit-puppeteer jshint prettier@2.0.5
+npm install -g node-qunit-puppeteer jshint prettier@2.0.5
 ```
 
 If you don't have `npm` installed, you will need to install that first.
 
 **Note**: if you can't install puppeteer, the (JavaScript) test suite can be
 run using a web browser by opening the page in `tests/index.html`.
+
+**Note**: Previously, we used [`qunit-puppeteer`](https://www.npmjs.com/package/qunit-puppeteer),
+but at some point this stopped working -- running it from the terminal halted forever. Using
+the more actively maintained [`node-qunit-puppeteer`](https://www.npmjs.com/package/node-qunit-puppeteer)
+package fixes this issue -- so, although these packages have very similar names,
+please make sure you are using the correct one.
 
 ## Running tests
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ CSSLOCS = empress/support_files/css/*.css
 test: pytest jstest
 
 pytest:
-	nosetests tests/python
+	python3 -B -m pytest tests/python --cov empress
 
 jstest:
 	@# Note: this assumes you're running this on a Linux/macOS system

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ jstest:
 	@# Note: this assumes you're running this on a Linux/macOS system
 	@# Also: previously, we used "qunit-puppeteer", but that stopped
 	@# working at some point. "node-qunit-puppeteer" is maintained and works
-	node-qunit-puppeteer file://$(shell pwd)/tests/index.html
+	node-qunit-puppeteer tests/index.html
 
 # Lints and checks code style
 stylecheck:

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,9 @@ pytest:
 
 jstest:
 	@# Note: this assumes you're running this on a Linux/macOS system
-	qunit-puppeteer file://$(shell pwd)/tests/index.html
+	@# Also: previously, we used "qunit-puppeteer", but that stopped
+	@# working at some point. "node-qunit-puppeteer" is maintained and works
+	node-qunit-puppeteer file://$(shell pwd)/tests/index.html
 
 # Lints and checks code style
 stylecheck:

--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ post a question on the [QIIME 2 Forum](https://forum.qiime2.org)!)
 
 ### Standalone Version
 
-Empress is available through [PyPI](https://PyPI.org/project/empress/). We recommend installing Empress into an environment (e.g. a [conda](https://docs.conda.io/) environment) using a Python version of at least 3.6.
+Empress is available through [PyPI](https://PyPI.org/project/empress/). As of writing, Empress supports Python versions 3.9, 3.10, 3.11, and 3.12.
 
 Run the following commands to install Empress:
 
 ```bash
-pip install cython "numpy >= 1.12.0"
+pip install cython "numpy >= 1.12.0,<2"
 pip install empress
 ```
 

--- a/empress/tools.py
+++ b/empress/tools.py
@@ -286,7 +286,13 @@ def match_inputs(
         if ignore_missing_samples:
             # Works similarly to how Emperor does this: see
             # https://github.com/biocore/emperor/blob/659b62a9f02a6423b6258c814d0e83dbfd05220e/emperor/core.py#L350
-            samples_without_metadata = table_samples - sm_samples
+            #
+            # NOTE: as of April 2025, we can't use a set as the index of a
+            # DataFrame. Since we don't care about the order of samples in
+            # the DataFrame, we can just get around this by converting the
+            # set of (table_samples - sm_samples) to a list, per
+            # https://stackoverflow.com/a/73778792
+            samples_without_metadata = list(table_samples - sm_samples)
             padded_metadata = pd.DataFrame(
                 index=samples_without_metadata,
                 columns=sample_metadata.columns,

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
     # Yanked from Qurro: NumPy and Cython need to be installed before
     # trying to install EMPress / other pip packages.
     # https://github.com/biocore/qurro/blob/master/setup.py
-    setup_requires=["cython", "numpy >= 1.12.0"],
+    setup_requires=["cython", "numpy >= 1.12.0, < 2"],
     install_requires=base,
     extras_require={'test': test, 'all': all_deps},
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ with open('README.md') as f:
 base = ["numpy", "scipy", "pandas", "click",
         "jinja2", "scikit-bio", "biom-format", "iow==0.1.3",
         "emperor>=1.0.2"]
-test = ["flake8", "nose"]
+test = ["flake8", "pytest", "pytest-cov"]
 all_deps = base + test
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -38,11 +38,12 @@ classifiers = [s.strip() for s in classes.split('\n') if s]
 with open('README.md') as f:
     long_description = f.read()
 
-# NOTE: Pinning iow due to issue described in
-# https://github.com/biocore/improved-octo-waddle/pull/48 and
-# https://github.com/biocore/empress/pull/555
+# NOTE: As described in https://github.com/biocore/empress/pull/555, iow needs
+# to be at least 0.1.3 for ordinary use of Empress. For testing, the "linear"
+# trees we check will cause versions of iow > 0.1.3 and < 1.0.8 to crash --
+# however, this should not impact ordinary use of Empress.
 base = ["numpy", "scipy", "pandas", "click",
-        "jinja2", "scikit-bio", "biom-format", "iow==0.1.3",
+        "jinja2", "scikit-bio", "biom-format", "iow>=0.1.3",
         "emperor>=1.0.2"]
 test = ["flake8", "pytest", "pytest-cov"]
 all_deps = base + test

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,8 @@ __maintainer__ = "Empress development team"
 __email__ = "kcantrel@ucsd.edu"
 
 # based on the text found in github.com/qiime/pynast
+# NOTE: these supported python versions (3.9 through 3.12) match iow 1.0.8;
+# as of writing, it does not yet support python 3.13.
 classes = """
     Development Status :: 5 - Production/Stable
     License :: OSI Approved :: BSD License
@@ -23,10 +25,10 @@ classes = """
     Topic :: Software Development :: User Interfaces
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     Operating System :: OS Independent
     Operating System :: POSIX

--- a/tests/python/test_core.py
+++ b/tests/python/test_core.py
@@ -13,7 +13,7 @@ import numpy as np
 import skbio
 
 from skbio.util import assert_ordination_results_equal
-from pandas.util.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal
 from os.path import exists
 from shutil import rmtree
 import biom
@@ -183,7 +183,12 @@ class TestCore(unittest.TestCase):
             },
             index=["weshould", "befiltered"]
         )
-        smooshed_fm = self.feature_metadata.append(extra_fm)
+        # Previously, we used self.feature_metadata.append() to do this
+        # (https://pandas.pydata.org/pandas-docs/version/1.4/reference/api/pandas.DataFrame.append.html)
+        # but this has since been removed from pandas. pd.concat() works as
+        # a replacement -- we are just adding the rows of extra_fm on to the
+        # end of self.feature_metadata.
+        smooshed_fm = pd.concat([self.feature_metadata, extra_fm])
         viz = Empress(self.tree, feature_metadata=smooshed_fm)
         self.assertFalse(viz.is_community_plot)
         assert_frame_equal(viz.tip_md, self.feature_metadata.loc[["a"]])

--- a/tests/python/test_taxonomy_utils.py
+++ b/tests/python/test_taxonomy_utils.py
@@ -57,9 +57,9 @@ class TestTaxonomyUtils(unittest.TestCase):
         )
 
     def _check_basic_case_worked(self, split_fm, taxcols):
-        """Checks that a given DataFrame (and list of split-up taxonomy columns)
-           matches the expected output from running split_taxonomy() on
-           self.feature_metadata.
+        """Checks that a given DataFrame (and list of split-up taxonomy
+           columns) matches the expected output from running split_taxonomy()
+           on self.feature_metadata.
         """
 
         # Let's verify that split_fm looks how we expect it to look.


### PR DESCRIPTION
This fixes both the `main` (QIIME 2 + Python tests + JS test) and `standalone` (just non-Q2 Python tests) builds. It took some finagling, but this should be ready for review now -- it addresses all of the build issues, with the exception of McHelper still being down.

Some notes:

- The `main` build is still failing because McHelper is not responding. Aside from that, everything else should be working.

- This updates the supported Python versions to {3.9, 3.10, 3.11, 3.12}, to match iow 1.0.8. (Note that iow 1.0.8 does not support 3.13 yet, and trying to include it in the build matrix fails due to iow not finding numpy.)

- This also imposes a numpy pin < 2, due to https://github.com/biocore/improved-octo-waddle/issues/59 (and #563). I verified that this pin is required to make the `standalone` build's tests pass. (The latest Q2 versions still use numpy < 2 as far as I can tell, so this is not an issue there, but I am sure they will update eventually.)

- Adjusted the main GitHub Actions workflow to test on a newer Q2 version (2024.10). It would be nice eventually to test on multiple Q2 versions.

- This replaces nosetests with pytest, because nose is no longer maintained and was causing some strange errors. Pytest seems to work well as a drop-in replacement.

  - While I was at it I added pytest-cov as an additional testing dependency, so now this reports python test coverage also (which is nice). Notably, this is not sufficient for #156, since it would be good to profile JS test coverage also. (Qurro has its own way of doing this, but it uses a different JS test runner.)

- For some reason, `qunit-puppeteer` (the JS test runner) isn't working any more (either on my laptop or on GH Actions). Looks like `node-qunit-puppeteer` (a different package with a similar name) is more actively maintained and does not have this issue, so I switched the JS tests to use this other package.